### PR TITLE
feat: 댓글 푸시 알림 서버 발송 로직

### DIFF
--- a/docs/push-tokens.sql
+++ b/docs/push-tokens.sql
@@ -1,0 +1,17 @@
+-- 하이브리드 앱 푸시 토큰 저장 테이블
+-- Supabase 대시보드 > SQL Editor에서 실행
+create table if not exists public.push_tokens (
+  token text primary key,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  platform text,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.push_tokens enable row level security;
+
+-- 본인 토큰만 등록/수정/삭제 가능. 다른 사용자 토큰 조회는 서버(service role)에서만.
+create policy "Users manage own push tokens"
+  on public.push_tokens
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/src/app/api/push/comment/route.ts
+++ b/src/app/api/push/comment/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
+import { truncate } from "lodash";
+
+const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
+
+//댓글 작성 시 게시글 작성자에게 푸시 알림 발송
+export async function POST(request: Request) {
+  try {
+    const { boardId, commentId } = await request.json();
+    if (typeof boardId !== "number" || typeof commentId !== "number") {
+      return NextResponse.json({ error: "잘못된 요청입니다." }, { status: 400 });
+    }
+
+    //쿠키 세션으로 댓글 작성자 본인 확인
+    const cookieStore = await cookies();
+    const authClient = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll: () => cookieStore.getAll(),
+          setAll: () => {},
+        },
+      },
+    );
+    const {
+      data: { user },
+    } = await authClient.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!serviceRoleKey) {
+      return NextResponse.json({ error: "푸시 발송 설정이 완료되지 않았습니다." }, { status: 500 });
+    }
+    const admin = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, serviceRoleKey, {
+      auth: { persistSession: false },
+    });
+
+    //요청한 댓글이 실제로 본인이 방금 작성한 댓글인지 검증
+    const { data: comment } = await admin
+      .from("board_comments")
+      .select("id, user_id, board_id")
+      .eq("id", commentId)
+      .single();
+    if (!comment || comment.user_id !== user.id || comment.board_id !== boardId) {
+      return NextResponse.json({ error: "댓글을 찾을 수 없습니다." }, { status: 404 });
+    }
+
+    const { data: board } = await admin.from("board").select("id, title, user_id").eq("id", boardId).single();
+    //본인 글에 단 댓글은 알림 제외
+    if (!board?.user_id || board.user_id === user.id) {
+      return NextResponse.json({ skipped: true });
+    }
+
+    const { data: tokens } = await admin.from("push_tokens").select("token").eq("user_id", board.user_id);
+    if (!tokens || tokens.length === 0) {
+      return NextResponse.json({ skipped: true });
+    }
+
+    const { data: commenter } = await admin.from("user").select("name").eq("id", user.id).single();
+    const commenterName = commenter?.name ?? "누군가";
+    const boardTitle = truncate(board.title ?? "게시글", { length: 15, omission: "..." });
+    const origin = new URL(request.url).origin;
+
+    const messages = tokens.map(({ token }) => ({
+      to: token,
+      title: "새 댓글이 달렸습니다",
+      body: `${commenterName}님이 "${boardTitle}" 글에 댓글을 남겼습니다.`,
+      data: { url: `${origin}/board/${boardId}` },
+    }));
+
+    const expoResponse = await fetch(EXPO_PUSH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(messages),
+    });
+    const expoResult = await expoResponse.json();
+
+    //만료된 토큰 정리
+    const staleTokens = (expoResult.data ?? [])
+      .map((ticket: { status: string; details?: { error?: string } }, index: number) =>
+        ticket.status === "error" && ticket.details?.error === "DeviceNotRegistered" ? tokens[index].token : null,
+      )
+      .filter(Boolean);
+    if (staleTokens.length > 0) {
+      await admin.from("push_tokens").delete().in("token", staleTokens);
+    }
+
+    return NextResponse.json({ sent: messages.length - staleTokens.length });
+  } catch (error) {
+    console.error("푸시 발송 실패:", error);
+    return NextResponse.json({ error: "푸시 발송에 실패했습니다." }, { status: 500 });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import QueryProvider from "@/providers/QueryProvider";
 import { notoSansKr } from "../assets/fonts/fonts";
 import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider } from "@/providers/AuthProvider";
+import PushTokenSync from "@/components/common/PushTokenSync";
 
 export const metadata: Metadata = {
   title: "IVE-DIVE",
@@ -45,6 +46,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <AuthProvider>
+            <PushTokenSync />
             <QueryProvider>
               <Header />
               {children}

--- a/src/components/common/PushTokenSync.tsx
+++ b/src/components/common/PushTokenSync.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSession } from "@/store/zustand";
+import { upsertPushToken } from "@/lib/supabase/pushToken";
+
+declare global {
+  interface Window {
+    __IVE_PUSH__?: {
+      token: string;
+      platform: string;
+    };
+  }
+}
+
+//하이브리드 앱 WebView에서 주입한 푸시 토큰을 로그인 사용자와 연결
+const PushTokenSync = () => {
+  const session = useSession();
+
+  useEffect(() => {
+    const userId = session?.user?.id;
+    if (!userId) return;
+
+    const sync = () => {
+      const push = window.__IVE_PUSH__;
+      if (!push?.token) return;
+      //실패해도 서비스 흐름에는 영향 없음
+      upsertPushToken(userId, push.token, push.platform).catch(() => {});
+    };
+
+    sync();
+    window.addEventListener("ive-push-token", sync);
+    return () => window.removeEventListener("ive-push-token", sync);
+  }, [session?.user?.id]);
+
+  return null;
+};
+
+export default PushTokenSync;

--- a/src/hooks/queries/useComment.ts
+++ b/src/hooks/queries/useComment.ts
@@ -30,6 +30,13 @@ export const useAddComment = (boardId: number) => {
   return useMutation({
     mutationFn: createComment,
     onSuccess: (newComment) => {
+      //게시글 작성자에게 푸시 알림 (실패해도 댓글 흐름에는 영향 없음)
+      fetch("/api/push/comment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ boardId, commentId: newComment.id }),
+      }).catch(() => {});
+
       if (newComment.parent_id) {
         queryClient.invalidateQueries({
           queryKey: ["comments", "replies", newComment.parent_id],

--- a/src/lib/supabase/pushToken.ts
+++ b/src/lib/supabase/pushToken.ts
@@ -1,0 +1,16 @@
+import { supabase } from "@/lib/supabase/client";
+
+//하이브리드 앱 WebView가 주입한 Expo 푸시 토큰을 로그인한 사용자에게 연결
+export const upsertPushToken = async (userId: string, token: string, platform?: string) => {
+  const { error } = await supabase.from("push_tokens").upsert(
+    {
+      token,
+      user_id: userId,
+      platform: platform ?? null,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "token" },
+  );
+
+  if (error) throw error;
+};


### PR DESCRIPTION
## 개요

하이브리드 앱(seokachu/ive-app) 사용자에게 댓글 푸시 알림을 발송하는 서버 로직입니다.

## 구조

- 앱이 푸시 토큰을 WebView 전역(window.__IVE_PUSH__)에 주입
- PushTokenSync가 로그인 사용자와 토큰을 연결해 push_tokens에 upsert (RLS 본인 제한)
- 댓글 작성 성공 시 POST /api/push/comment 호출 (fire-and-forget)
- 서버가 쿠키 세션으로 작성자 검증 후 글 작성자에게 Expo Push 발송
  (본인 글 제외, DeviceNotRegistered 토큰 자동 정리)

## 사전 준비 (완료)

- Supabase push_tokens 테이블 + RLS (docs/push-tokens.sql)
- Vercel 환경변수 SUPABASE_SERVICE_ROLE_KEY (Production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added push notification support for new comments.
  * Notifications include a direct link to the relevant board.
  * Added automatic synchronization of device push tokens for signed-in users.
  * Expired device tokens are automatically removed.
  * Users can only access their own registered push tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->