### PR TITLE
fix: 결제 복귀 시 로그인 페이지로 튕기는 문제 수정

### DIFF
--- a/src/hooks/AuthGuard.tsx
+++ b/src/hooks/AuthGuard.tsx
@@ -22,21 +22,25 @@ const AuthGuard = ({ children, loadingComponent }: AuthGuardProps) => {
   }, [initializeAuth]);
 
   useEffect(() => {
-    const showToastAndRedirect = () => {
-      if (isInitialized && !session) {
-        Promise.resolve(
-          toast({
-            title: "로그인 후 이용 가능합니다.",
-            duration: 2000,
-          }),
-        ).then(() => {
-          setTimeout(() => {
-            window.location.href = "/login";
-          }, 1500);
-        });
-      }
+    if (!isInitialized || session) return;
+
+    //세션 복원이 끝나기 전에 성급하게 튕기지 않도록 잠깐 기다렸다가 이동한다.
+    //그 사이 세션이 생기면 effect가 재실행되며 아래 cleanup으로 타이머가 취소된다.
+    let redirectTimer: ReturnType<typeof setTimeout>;
+    const checkTimer = setTimeout(() => {
+      toast({
+        title: "로그인 후 이용 가능합니다.",
+        duration: 2000,
+      });
+      redirectTimer = setTimeout(() => {
+        window.location.href = "/login";
+      }, 1500);
+    }, 300);
+
+    return () => {
+      clearTimeout(checkTimer);
+      clearTimeout(redirectTimer);
     };
-    setTimeout(showToastAndRedirect, 100);
   }, [session, isInitialized]);
 
   if (!isInitialized || !session) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -39,10 +39,9 @@ export async function proxy(request: NextRequest) {
       request.nextUrl.pathname.startsWith("/payment/success") ||
       request.nextUrl.pathname.startsWith("/payment/fail")
     ) {
-      //로그인 체크
-      if (!user) {
-        return NextResponse.redirect(new URL("/login", request.url));
-      }
+      //PG(토스) 결제 후 복귀는 크로스 사이트 리다이렉트라 SameSite=Lax 쿠키가
+      //요청에 실리지 않을 수 있다. 서버에서 로그인을 검사하면 실제 로그인
+      //사용자도 튕기므로, 이 경로의 인증은 클라이언트 AuthGuard가 담당한다.
       //orderId 파라미터 체크
       const orderId = request.nextUrl.searchParams.get("orderId");
       if (!orderId) {


### PR DESCRIPTION
## 문제

하이브리드 앱(WebView)에서 토스 결제 완료 후 /payment/success로 복귀하면
로그인 상태인데도 로그인 페이지로 리다이렉트됨.

## 원인

PG 결제 복귀는 크로스 사이트 리다이렉트 → SameSite=Lax 정책으로 세션 쿠키가
해당 요청에 실리지 않을 수 있음 → 서버 가드(proxy)가 비로그인으로 오판.
같은 사이트 내 이동인 /mypage는 정상이었던 이유.

## 수정

- /payment/success·fail의 인증을 클라이언트 AuthGuard로 이관
  (클라이언트 JS는 쿠키를 항상 읽을 수 있어 SameSite 영향 없음)
- AuthGuard의 리다이렉트 타이머 레이스 수정 (cleanup 누락)

🤖 Generated with [Claude Code](https://claude.com/claude-code)