### PR TITLE
feat: 장바구니·결제 플로우 리디자인

### DIFF
--- a/e2e/cart-actions.spec.ts
+++ b/e2e/cart-actions.spec.ts
@@ -4,7 +4,7 @@ test.describe("cart actions", () => {
   test("moves from the empty cart to the shop page", async ({ page }) => {
     await page.goto("/cart");
 
-    await page.getByRole("link", { name: "쇼핑하기" }).click();
+    await page.getByRole("link", { name: "굿즈샵 구경하러 가기" }).click();
 
     await expect(page).toHaveURL(/\/shop$/);
     await expect(page.getByRole("heading", { name: "Goods Shop" })).toBeVisible();

--- a/e2e/cart.spec.ts
+++ b/e2e/cart.spec.ts
@@ -4,6 +4,6 @@ test("renders the empty cart state for a new visitor", async ({ page }) => {
   await page.goto("/cart");
 
   await expect(page.getByRole("heading", { name: "장바구니", exact: true })).toBeVisible();
-  await expect(page.getByText("장바구니가 비어있습니다.")).toBeVisible();
-  await expect(page.getByRole("link", { name: "쇼핑하기" })).toHaveAttribute("href", "/shop");
+  await expect(page.getByText("장바구니가 비어 있어요")).toBeVisible();
+  await expect(page.getByRole("link", { name: "굿즈샵 구경하러 가기" })).toHaveAttribute("href", "/shop");
 });

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,15 +1,26 @@
 import CartList from "@/components/cart/CartList";
 import CartSummary from "@/components/cart/CartSummary";
+import CheckoutSteps from "@/components/cart/CheckoutSteps";
 import { cartMetadata } from "@/metadata/cart/cartMetadata";
 
 export const metadata = cartMetadata;
 
 const page = () => {
   return (
-    <section className="px-0 pt-14 pb-28 lg:px-8 bg-gray-100 min-h-screen flex items-center justify-center">
-      <div className="max-w-container w-full m-auto flex flex-col lg:flex-row gap-5">
-        <CartList />
-        <CartSummary />
+    <section className="min-h-screen px-5 pb-28 pt-8 lg:px-8">
+      <div className="mx-auto w-full max-w-container">
+        <div className="flex flex-col gap-5 pb-7 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-[13px] font-bold tracking-[0.2em] text-orange-500">SHOPPING CART</p>
+            <h1 className="mt-2 text-3xl font-bold lg:text-[34px]">장바구니</h1>
+            <p className="mt-2.5 text-[15px] text-gray-500">담아둔 굿즈를 확인하고 바로 결제까지 진행해요</p>
+          </div>
+          <CheckoutSteps current={1} />
+        </div>
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
+          <CartList />
+          <CartSummary />
+        </div>
       </div>
     </section>
   );

--- a/src/components/cart/AgreementCheckbox.tsx
+++ b/src/components/cart/AgreementCheckbox.tsx
@@ -4,13 +4,13 @@ import type { AgreementCheckboxProps } from "@/types/cart";
 
 const AgreementCheckbox = ({ modalType, onChange, checked, labelText }: AgreementCheckboxProps) => {
   return (
-    <div className="flex items-center justify-between">
-      <label className="flex items-baseline">
-        <input type="checkbox" className="mr-2 translate-y-[1px]" checked={checked} onChange={onChange} />
+    <div className="flex items-center justify-between gap-2">
+      <label className="flex cursor-pointer items-baseline gap-2 text-[13px] text-gray-500">
+        <input type="checkbox" className="translate-y-[2px]" checked={checked} onChange={onChange} />
         {labelText}
       </label>
-      <Button variant="plain" size="auto" onClick={modalType}>
-        <ChevronRight className="text-gray-500" />
+      <Button variant="plain" size="auto" onClick={modalType} aria-label="약관 전문 보기">
+        <ChevronRight size={16} className="text-gray-400" />
       </Button>
     </div>
   );

--- a/src/components/cart/CartList.tsx
+++ b/src/components/cart/CartList.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import useLoading from "@/hooks/useLoading";
 import CartListLoading from "../common/loading/CartListLoading";
 import { toast } from "@/hooks/use-toast";
+import { ShoppingCart, Truck } from "lucide-react";
 import SelectionControl from "../common/select/SelectionControl";
 import { useCartActions, useCartItems, useCheckoutActions, useSelectedItemIds } from "@/store/zustand";
 
@@ -39,7 +40,7 @@ const CartList = () => {
     }
   };
 
-  //선택삭제 버튼
+  //선택삭제 버튼 — 확인 없이 즉시 삭제 (시안 기준)
   const handleDeleteSelected = () => {
     if (selectedItems.length === 0) {
       toast({
@@ -57,7 +58,7 @@ const CartList = () => {
     });
   };
 
-  //전체삭제 확인 액션
+  //전체 비우기 확인 액션
   const handleConfirmDeleteAll = () => {
     localStorage.setItem("shopping_cart", JSON.stringify([]));
     setCartItems([]);
@@ -65,8 +66,7 @@ const CartList = () => {
   };
 
   return (
-    <div className="flex-[2] p-5 lg:p-10 border rounded-md bg-card shadow-sm h-fit">
-      <h2 className="font-bold text-lg lg:text-xl">장바구니</h2>
+    <div className="min-w-0 flex-1">
       {mounted && cartItems.length > 0 ? (
         <>
           <SelectionControl
@@ -75,27 +75,34 @@ const CartList = () => {
             onSelectAll={handleSelectAll}
             onDeleteSelected={handleDeleteSelected}
             onConfirm={handleConfirmDeleteAll}
-            title="장바구니 비우기"
-            description="장바구니의 모든 상품이 삭제됩니다. 정말 비우시겠습니까?"
+            title="장바구니를 비울까요?"
+            description="담아둔 상품이 모두 삭제돼요. 이 작업은 되돌릴 수 없어요."
             cancelText="취소"
             confirmText="비우기"
           />
-          <ul>
+          <ul className="mt-3 flex flex-col gap-3.5">
             {cartItems.map((item) => (
               <CartListItem key={item.id} item={item} />
             ))}
           </ul>
+          <div className="mt-3.5 flex items-center gap-2.5 rounded-xl bg-purple-50 px-4 py-3">
+            <Truck size={18} className="shrink-0 text-purple-400" aria-hidden />
+            <p className="text-[13px] text-gray-500">전 상품 무료배송 · 지금 주문하면 오늘 바로 출발해요</p>
+          </div>
         </>
       ) : (
-        <div className="flex items-center justify-center min-h-[500px]">
-          <div className="flex items-center justify-center flex-col gap-2">
-            <h3>장바구니가 비어있습니다.</h3>
-            <p className="text-gray-500 text-sm mb-5">원하는 상품을 담아보세요!</p>
+        <div className="flex min-h-[480px] items-center justify-center rounded-2xl border border-gray-200 bg-card">
+          <div className="flex flex-col items-center">
+            <span className="flex h-16 w-16 items-center justify-center rounded-full bg-purple-50" aria-hidden>
+              <ShoppingCart size={26} className="text-purple-400" />
+            </span>
+            <h3 className="mt-5 text-lg font-bold">장바구니가 비어 있어요</h3>
+            <p className="mt-1.5 text-sm text-gray-500">마음에 드는 굿즈를 담아보세요!</p>
             <Link
               href="/shop"
-              className="border text-sm py-2 px-5 rounded-md border-purple text-purple hover:text-white hover:bg-purple transition-all ease-out duration-300"
+              className="mt-6 flex h-12 items-center rounded-full bg-purple-300 px-7 text-sm font-bold text-white transition-colors hover:bg-purple-400"
             >
-              쇼핑하기
+              굿즈샵 구경하러 가기
             </Link>
           </div>
         </div>

--- a/src/components/cart/CartListItem.tsx
+++ b/src/components/cart/CartListItem.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import DefaultImage from "@/assets/images/default_image.avif";
 import { formatPrice, getDiscountedPrice } from "@/utils/calculateDiscount";
 import Image from "next/image";
+import { X } from "lucide-react";
 import { useEffect, useId } from "react";
 import QuantitySelector from "../common/QuantitySelector";
 import { toast } from "@/hooks/use-toast";
@@ -106,54 +107,56 @@ const CartListItem = ({ item }: CartListItemProps) => {
   };
 
   return (
-    <li className="px-2 py-4 relative border-b">
-      <label htmlFor={`${item.id}-${id}`} className="flex">
-        <input
-          onChange={handleCheck}
-          checked={isChecked}
-          type="checkbox"
-          id={`${item.id}-${id}`}
-          className="w-4 h-4 flex-shrink-0"
-        />
+    <li className="relative rounded-2xl border border-gray-200 bg-card p-5">
+      <label htmlFor={`${item.id}-${id}`} className="flex items-center gap-4">
+        <input onChange={handleCheck} checked={isChecked} type="checkbox" id={`${item.id}-${id}`} className="shrink-0" />
         <div
           onClick={onClickDetailPage}
-          className="relative w-[80px] h-[80px] overflow-hidden rounded-md mx-5 flex-shrink-0 border cursor-pointer"
+          className="relative h-[88px] w-[88px] shrink-0 cursor-pointer overflow-hidden rounded-xl border border-gray-200"
         >
           <Image
             src={item.thumbnail || DefaultImage}
             alt={item.title}
-            className="object-cover fill"
-            width={80}
-            height={80}
+            className="h-full w-full object-cover"
+            width={88}
+            height={88}
           />
         </div>
-        <div className="flex w-full lg:gap-3 lg:flex-row flex-col lg:items-center lg:justify-between">
-          <div className="flex-[4] mr-9 flex flex-col justify-between">
-            <h3 className="flex flex-wrap gap-1 lg:items-center flex-col lg:flex-row">
-              <span className="font-bold shrink-0">{item.title}</span>
-              <span className="text-sm lg:text-xs text-gray-500 shrink-0">{item.delivery_info}</span>
-            </h3>
-            <p className="text-gray-500 text-sm flex flex-wrap flex-col lg:flex-row gap-1 my-1 uppercase">
-              <span className="shrink-0">사이즈 : {item.size}</span>
-              <span className="hidden lg:block">&#47;</span>
-              <span className="shrink-0">색상 : {item.color}</span>
-            </p>
-            <QuantitySelector
-              className="text-sm text-gray-400 mr-3"
-              quantity={item.quantity}
-              increase={handleIncrease}
-              decrease={handleDecrease}
-            />
-          </div>
-          <div className="lg:text-right flex-1">
-            <span className="mr-1 text-purple font-bold">{item.discount_rate}%</span>
-            <s className="text-gray-300 text-sm mr-1 lg:mr-0 text-nowrap">{formatPrice(price)}원</s>
-            <strong>{formatPrice(totalDiscountPrice)}원</strong>
-          </div>
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <h3 className="flex flex-wrap items-center gap-2 pr-6">
+            <span className="text-[15px] font-bold">{item.title}</span>
+            {item.delivery_info && (
+              <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] text-gray-500">
+                {item.delivery_info}
+              </span>
+            )}
+          </h3>
+          <p className="text-[13px] uppercase text-gray-400">
+            사이즈 {item.size} · 색상 {item.color}
+          </p>
+          <QuantitySelector
+            className="mt-1"
+            quantity={item.quantity}
+            increase={handleIncrease}
+            decrease={handleDecrease}
+          />
+        </div>
+        <div className="flex shrink-0 flex-col items-end gap-0.5 pr-1 lg:pr-4">
+          <span className="flex items-center gap-1.5 text-[13px]">
+            <strong className="font-bold text-orange-500">{item.discount_rate}%</strong>
+            <s className="text-gray-300">{formatPrice(price)}원</s>
+          </span>
+          <strong className="text-lg font-bold">{formatPrice(totalDiscountPrice)}원</strong>
         </div>
       </label>
-      <Button variant="plain" size="auto" onClick={handleDeleteItem} className="absolute right-2 top-[10px] hover:text-purple">
-        &times;
+      <Button
+        variant="plain"
+        size="auto"
+        onClick={handleDeleteItem}
+        className="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full text-gray-400 hover:bg-gray-50 hover:text-gray-500"
+        aria-label={`${item.title} 삭제`}
+      >
+        <X size={15} />
       </Button>
     </li>
   );

--- a/src/components/cart/CartSummary.tsx
+++ b/src/components/cart/CartSummary.tsx
@@ -36,20 +36,23 @@ const CartSummary = () => {
   const totalDiscountAmount = totalOriginalPrice - totalDiscountedPrice;
 
   return mounted ? (
-    <div className="lg:sticky lg:top-5 flex-1 border rounded-md bg-card shadow-sm p-5 lg:p-10 h-fit">
-      <OrderPriceSummary
-        totalDiscountedPrice={totalDiscountedPrice}
-        totalOriginalPrice={totalOriginalPrice}
-        totalDiscountAmount={totalDiscountAmount}
-      />
+    <aside className="flex w-full flex-col gap-4 lg:sticky lg:top-24 lg:w-[400px] lg:shrink-0">
+      <div className="rounded-[20px] border border-gray-200 bg-card p-7 shadow-[0_12px_32px_rgba(169,79,192,0.10)]">
+        <OrderPriceSummary
+          totalDiscountedPrice={totalDiscountedPrice}
+          totalOriginalPrice={totalOriginalPrice}
+          totalDiscountAmount={totalDiscountAmount}
+        />
+        <OrderAgreements />
+        <PaymentButton
+          amount={totalDiscountedPrice}
+          orderName={`${selectedCartItems[0]?.title} 외 ${selectedCartItems.length - 1}건`}
+        />
+        <p className="mt-3.5 text-center text-xs text-gray-400">본인은 만 14세 이상이며 주문 내용을 확인했어요</p>
+      </div>
       <OrderCustomerInfo />
       <OrderShippingInfo />
-      <OrderAgreements />
-      <PaymentButton
-        amount={totalDiscountedPrice}
-        orderName={`${selectedCartItems[0]?.title} 외 ${selectedCartItems.length - 1}건`}
-      />
-    </div>
+    </aside>
   ) : (
     <CartSummarySkeleton />
   );

--- a/src/components/cart/CheckoutSteps.tsx
+++ b/src/components/cart/CheckoutSteps.tsx
@@ -1,0 +1,43 @@
+import { Check, ChevronRight } from "lucide-react";
+
+const STEPS = ["장바구니", "주문·결제", "주문완료"] as const;
+
+interface CheckoutStepsProps {
+  /** 현재 단계 (1=장바구니, 2=주문·결제, 3=주문완료) */
+  current: 1 | 2 | 3;
+}
+
+const CheckoutSteps = ({ current }: CheckoutStepsProps) => {
+  return (
+    <ol className="flex items-center gap-2.5">
+      {STEPS.map((label, index) => {
+        const step = index + 1;
+        const isActive = step === current;
+        const isDone = step < current;
+
+        return (
+          <li key={label} className="flex items-center gap-2.5">
+            {index > 0 && <ChevronRight size={14} className="text-gray-300" aria-hidden />}
+            <span className="flex items-center gap-1.5">
+              <span
+                className={`flex h-[22px] w-[22px] items-center justify-center rounded-full text-[11px] font-bold ${
+                  isActive
+                    ? "bg-purple-300 text-white"
+                    : isDone
+                      ? "bg-purple-50 text-purple-400"
+                      : "bg-gray-100 text-gray-400"
+                }`}
+                aria-hidden
+              >
+                {isDone ? <Check size={12} /> : `0${step}`}
+              </span>
+              <span className={`text-[13px] ${isActive ? "font-semibold" : "text-gray-400"}`}>{label}</span>
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+};
+
+export default CheckoutSteps;

--- a/src/components/cart/CustomerInfoForm.tsx
+++ b/src/components/cart/CustomerInfoForm.tsx
@@ -99,72 +99,73 @@ const CustomerInfoForm = ({ initialData, defaultValues, onSuccess }: CustomerInf
   };
 
   return (
-    <div className="mb-12">
-      <div className="flex justify-between border-b pb-4 mb-5">
-        <h2 className="font-bold">주문자 정보</h2>
-      </div>
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-          <ul className="flex flex-col gap-2">
-            <li className="flex items-baseline">
-              <Label htmlFor="name" className="w-[100px] text-gray-400">
-                받는 분
-              </Label>
-              <div className="flex-1">
-                <RHFInput
-                  id="name"
-                  name="name"
-                  placeholder="이름을 입력해 주세요."
-                  messageClassName="text-xs py-1 px-3"
-                  className="rounded-sm py-0 px-4 w-full"
-                  maxLength={25}
-                />
-              </div>
-            </li>
-            <li className="flex items-baseline">
-              <Label htmlFor="phone" className="w-[100px] text-gray-400">
-                휴대폰 번호
-              </Label>
-              <div className="flex-1">
-                <RHFInput
-                  id="phone"
-                  name="phone"
-                  placeholder="하이픈(-) 없이 입력"
-                  pattern="[0-9]*"
-                  type="tel"
-                  inputMode="numeric"
-                  className="rounded-sm py-0 px-4 w-full"
-                  messageClassName="text-xs py-1 px-3"
-                  maxLength={11}
-                />
-              </div>
-            </li>
-            <li className="flex items-baseline">
-              <Label htmlFor="email" className="w-[100px] text-gray-400">
-                이메일 주소
-              </Label>
-              <div className="flex-1">
-                <RHFInput
-                  id="email"
-                  name="email"
-                  placeholder="example@email.com"
-                  className="rounded-sm py-0 px-4 w-full"
-                  messageClassName="text-xs py-1 px-3"
-                />
-              </div>
-            </li>
-          </ul>
-          <div className="flex gap-2 pt-1">
-            <Button type="submit" className="flex-1 py-2 text-xs" disabled={!isValid || isSubmitting}>
-              {isSubmitting ? "저장 중..." : "저장하기"}
-            </Button>
-            <Button type="button" variant="outline" onClick={() => onSuccess()} className="flex-1 py-2 text-xs">
-              취소
-            </Button>
-          </div>
-        </form>
-      </Form>
-    </div>
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="mt-4">
+        <ul className="flex flex-col gap-3.5">
+          <li>
+            <Label htmlFor="name" className="mb-1.5 block text-[13px] font-semibold">
+              받는 분
+            </Label>
+            <RHFInput
+              id="name"
+              name="name"
+              placeholder="이름을 입력해 주세요."
+              messageClassName="text-xs py-1 px-1"
+              className="h-11 w-full rounded-lg px-4"
+              maxLength={25}
+            />
+          </li>
+          <li>
+            <Label htmlFor="phone" className="mb-1.5 block text-[13px] font-semibold">
+              휴대폰 번호
+            </Label>
+            <RHFInput
+              id="phone"
+              name="phone"
+              placeholder="하이픈(-) 없이 입력"
+              pattern="[0-9]*"
+              type="tel"
+              inputMode="numeric"
+              className="h-11 w-full rounded-lg px-4"
+              messageClassName="text-xs py-1 px-1"
+              maxLength={11}
+            />
+          </li>
+          <li>
+            <Label htmlFor="email" className="mb-1.5 block text-[13px] font-semibold">
+              이메일 주소
+            </Label>
+            <RHFInput
+              id="email"
+              name="email"
+              placeholder="example@email.com"
+              className="h-11 w-full rounded-lg px-4"
+              messageClassName="text-xs py-1 px-1"
+            />
+          </li>
+        </ul>
+        <div className="mt-5 flex gap-2.5">
+          <Button
+            type="button"
+            variant="plain"
+            size="auto"
+            onClick={() => onSuccess()}
+            className="h-[42px] flex-1 rounded-full border border-gray-300 text-[13px] font-semibold text-gray-500 hover:bg-gray-50"
+          >
+            취소
+          </Button>
+          <Button
+            type="submit"
+            variant="plain"
+            size="auto"
+            disabled={!isValid || isSubmitting}
+            className="h-[42px] flex-1 rounded-full bg-purple-300 text-[13px] font-bold text-white transition-colors hover:bg-purple-400"
+          >
+            {isSubmitting ? "저장 중..." : "저장하기"}
+          </Button>
+        </div>
+      </form>
+    </Form>
   );
 };
 

--- a/src/components/cart/EmptyStateMessage.tsx
+++ b/src/components/cart/EmptyStateMessage.tsx
@@ -2,16 +2,12 @@ import type { EmptyStateMessageProps } from "@/types/cart";
 
 const EmptyStateMessage = ({ title, message }: EmptyStateMessageProps) => {
   return (
-    <div className="mb-12">
-      <div className="flex justify-between border-b pb-4 mb-5">
-        <h2 className="font-bold">{title}</h2>
+    <div className="rounded-2xl border border-gray-200 bg-card p-6">
+      <h2 className="text-[15px] font-bold">{title}</h2>
+      <div className="my-7 flex flex-col items-center gap-1 text-sm">
+        <h3>{message}</h3>
+        <p className="text-[13px] text-gray-400">로그인 후 정보를 입력해주세요.</p>
       </div>
-      <ul className="flex flex-col justify-between gap-2 text-sm">
-        <li className="flex items-center justify-center flex-col gap-1 my-8">
-          <h3>{message}</h3>
-          <p>로그인 후 정보를 입력해주세요.</p>
-        </li>
-      </ul>
     </div>
   );
 };

--- a/src/components/cart/OrderAgreements.tsx
+++ b/src/components/cart/OrderAgreements.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
-import { ChevronUp } from "lucide-react";
 import AgreementModal from "./AgreementModal";
 import AgreementCheckbox from "./AgreementCheckbox";
 import { useAgreements, useCheckoutActions } from "@/store/zustand";
@@ -44,7 +43,7 @@ const OrderAgreements = () => {
     }
   };
 
-  //모달창 열기
+  //약관 목록 펼치기/접기
   const handleToggle = () => {
     setIsOpen(!isOpen);
   };
@@ -60,45 +59,37 @@ const OrderAgreements = () => {
   };
 
   return (
-    <div>
-      <h2 className="font-bold border-b pb-4 mb-5">주문동의</h2>
-      <div className="text-sm space-y-2">
-        <div>
-          <div className="flex items-center justify-between cursor-pointer" onClick={handleToggle}>
-            <label className="flex items-center" onClick={(e) => e.stopPropagation()}>
-              <input
-                type="checkbox"
-                className="mr-2"
-                checked={agreements.main}
-                onChange={handleAgreementChange("main")}
-              />
-              &#91;필수&#93; 주문 내역에 대한 필수 동의
-            </label>
-            <Button variant="plain" size="auto" type="button" className="text-gray-500" aria-label={isOpen ? "접기" : "펼치기"}>
-              <ChevronUp
-                className={`transition-transform duration-300 ease-in-out ${isOpen ? "rotate-0" : "rotate-180"}`}
-              />
-            </Button>
-          </div>
-          {isOpen && (
-            <div className="pl-6 mt-3 space-y-2">
-              <AgreementCheckbox
-                modalType={() => handleOpenModal("privacy")}
-                onChange={handleAgreementChange("privacy")}
-                checked={agreements.privacy}
-                labelText="&#91;필수&#93; 개인정보 수집 및 이용 및 제 3자 제공 동의"
-              />
-              <AgreementCheckbox
-                modalType={() => handleOpenModal("refund")}
-                onChange={handleAgreementChange("refund")}
-                checked={agreements.refund}
-                labelText="&#91;필수&#93; 결제 이후 환불 및 취소 불가 동의"
-              />
-            </div>
-          )}
-        </div>
+    <div className="mt-5">
+      <div className="flex items-center justify-between">
+        <label className="flex cursor-pointer items-center gap-2 text-[13px] text-gray-500">
+          <input type="checkbox" checked={agreements.main} onChange={handleAgreementChange("main")} />
+          &#91;필수&#93; 주문 내역 확인 및 결제 동의
+        </label>
+        <Button
+          variant="plain"
+          size="auto"
+          onClick={handleToggle}
+          className="text-xs text-gray-400 underline underline-offset-2 hover:text-gray-500"
+        >
+          {isOpen ? "접기" : "약관 보기"}
+        </Button>
       </div>
-      <h3 className="text-gray-400 text-sm text-center my-3">본인은 만 14세 이상이며 주문내용을 확인하였습니다.</h3>
+      {isOpen && (
+        <div className="mt-2.5 flex flex-col gap-2 rounded-xl bg-gray-50 p-3.5">
+          <AgreementCheckbox
+            modalType={() => handleOpenModal("privacy")}
+            onChange={handleAgreementChange("privacy")}
+            checked={agreements.privacy}
+            labelText="&#91;필수&#93; 개인정보 수집 및 이용 및 제 3자 제공 동의"
+          />
+          <AgreementCheckbox
+            modalType={() => handleOpenModal("refund")}
+            onChange={handleAgreementChange("refund")}
+            checked={agreements.refund}
+            labelText="&#91;필수&#93; 결제 이후 환불 및 취소 불가 동의"
+          />
+        </div>
+      )}
       <AgreementModal type={selectedAgreement} isOpen={selectedAgreement !== null} onClose={handleCloseModal} />
     </div>
   );

--- a/src/components/cart/OrderCustomerInfo.tsx
+++ b/src/components/cart/OrderCustomerInfo.tsx
@@ -15,40 +15,41 @@ const OrderCustomerInfo = () => {
     return <EmptyStateMessage title="주문자 정보" message="주문자 정보가 없습니다." />;
   }
 
-  // 주문자 정보 입력 & 수정 form
-  if (isEditing) {
-    return (
-      <CustomerInfoForm
-        initialData={customerInfo}
-        defaultValues={{
-          name: session.user.user_metadata?.name,
-          email: session.user.email,
-        }}
-        onSuccess={() => setIsEditing(false)}
-      />
-    );
-  }
-
   return (
-    <div className="mb-12">
-      <div className="flex justify-between border-b pb-4 mb-5">
-        <h2 className="font-bold">주문자 정보</h2>
-        <Button size="auto" className="text-xs px-2" onClick={() => setIsEditing(true)}>
-          {customerInfo ? "정보 변경" : "정보 입력"}
-        </Button>
-      </div>
-      <ul className="flex flex-col justify-between gap-2 text-sm">
-        {!customerInfo ? (
-          <li className="flex items-center justify-center flex-col gap-1 my-8">
-            <h3>주문자 정보가 없습니다.</h3>
-            <p>주문자 정보를 입력해주세요.</p>
-          </li>
-        ) : (
-          <>
-            <OrderCustomerInfoItem item={customerInfo} />
-          </>
+    <div className="rounded-2xl border border-gray-200 bg-card p-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-[15px] font-bold">주문자 정보</h2>
+        {!isEditing && (
+          <Button
+            variant="plain"
+            size="auto"
+            className="rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-500 hover:bg-gray-50"
+            onClick={() => setIsEditing(true)}
+          >
+            {customerInfo ? "변경" : "입력"}
+          </Button>
         )}
-      </ul>
+      </div>
+      {isEditing ? (
+        // 주문자 정보 입력 & 수정 인라인 폼
+        <CustomerInfoForm
+          initialData={customerInfo}
+          defaultValues={{
+            name: session.user.user_metadata?.name,
+            email: session.user.email,
+          }}
+          onSuccess={() => setIsEditing(false)}
+        />
+      ) : !customerInfo ? (
+        <div className="my-7 flex flex-col items-center gap-1 text-sm">
+          <h3>주문자 정보가 없습니다.</h3>
+          <p className="text-[13px] text-gray-400">주문자 정보를 입력해주세요.</p>
+        </div>
+      ) : (
+        <ul className="mt-3.5 flex flex-col gap-2 text-[13px]">
+          <OrderCustomerInfoItem item={customerInfo} />
+        </ul>
+      )}
     </div>
   );
 };

--- a/src/components/cart/OrderCustomerInfoItem.tsx
+++ b/src/components/cart/OrderCustomerInfoItem.tsx
@@ -4,16 +4,16 @@ const OrderCustomerInfoItem = ({ item }: OrderCustomerInfoItemProps) => {
   return (
     <>
       <li className="flex">
-        <h3 className="w-[100px] text-gray-400">받는 분</h3>
+        <h3 className="w-[80px] shrink-0 text-gray-400">받는 분</h3>
         <p>{item?.name}</p>
       </li>
       <li className="flex">
-        <h3 className="w-[100px] text-gray-400">휴대폰 번호</h3>
+        <h3 className="w-[80px] shrink-0 text-gray-400">휴대폰 번호</h3>
         <p>{item?.phone}</p>
       </li>
       <li className="flex">
-        <h3 className="w-[100px] text-gray-400">이메일 주소</h3>
-        <p>{item?.email}</p>
+        <h3 className="w-[80px] shrink-0 text-gray-400">이메일 주소</h3>
+        <p className="min-w-0 break-all">{item?.email}</p>
       </li>
     </>
   );

--- a/src/components/cart/OrderPriceSummary.tsx
+++ b/src/components/cart/OrderPriceSummary.tsx
@@ -7,23 +7,30 @@ const OrderPriceSummary = ({
   totalDiscountAmount,
 }: OrderPriceSummaryProps) => {
   return (
-    <div className="mb-12">
-      <h2 className="font-bold text-lg lg:text-xl mb-5">결제 금액</h2>
-      <div className="border-b pb-3 flex justify-between items-center">
-        <p>총 결제 금액</p>
-        <p>
-          <strong className="text-lg lg:text-xl mr-1 text-purple">{formatPrice(totalDiscountedPrice)}</strong>원
-        </p>
-      </div>
-      <div className="pt-5">
-        <p className="mb-1 flex justify-between items-center">
-          상품 금액
-          <span>{formatPrice(totalOriginalPrice)}원</span>
-        </p>
-        <p className="flex justify-between items-center">
-          총 할인 금액
-          <span className="text-orange-500">-{formatPrice(totalDiscountAmount)}원</span>
-        </p>
+    <div>
+      <h2 className="text-lg font-bold">결제 금액</h2>
+      <dl className="mt-4 flex flex-col gap-2.5 text-sm">
+        <div className="flex items-center justify-between">
+          <dt className="text-gray-500">상품 금액</dt>
+          <dd className="font-semibold">{formatPrice(totalOriginalPrice)}원</dd>
+        </div>
+        <div className="flex items-center justify-between">
+          <dt className="text-gray-500">할인 금액</dt>
+          <dd className="font-semibold text-orange-500">-{formatPrice(totalDiscountAmount)}원</dd>
+        </div>
+        <div className="flex items-center justify-between">
+          <dt className="text-gray-500">배송비</dt>
+          <dd className="font-semibold">무료</dd>
+        </div>
+      </dl>
+      <div className="mt-4 flex items-end justify-between border-t border-gray-200 pt-4">
+        <span className="text-sm font-semibold">총 결제 금액</span>
+        <span className="flex items-end gap-0.5">
+          <strong className="text-[26px] font-bold leading-none text-purple-500 dark:text-purple-300">
+            {formatPrice(totalDiscountedPrice)}
+          </strong>
+          <span className="text-[15px] font-semibold leading-tight">원</span>
+        </span>
       </div>
     </div>
   );

--- a/src/components/cart/OrderShippingInfo.tsx
+++ b/src/components/cart/OrderShippingInfo.tsx
@@ -1,13 +1,16 @@
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useShippingAddress } from "@/hooks/queries/useShippingAddress";
 import EmptyStateMessage from "./EmptyStateMessage";
+import ShippingAddressPicker from "./ShippingAddressPicker";
 import { useSession } from "@/store/zustand";
 
 const OrderShippingInfo = () => {
   const { push } = useRouter();
   const session = useSession();
   const { data: shippingAddress } = useShippingAddress(session?.user.id);
+  const [isPicking, setIsPicking] = useState(false);
 
   if (!session) {
     return <EmptyStateMessage title="배송 정보" message="배송 정보가 없습니다." />;
@@ -15,57 +18,61 @@ const OrderShippingInfo = () => {
 
   const hasShippingAddress = shippingAddress && Object.keys(shippingAddress).length > 0;
 
+  //배송지 없으면 추가 페이지로, 있으면 인라인 배송지 선택 토글
   const handleShippingAddressChange = () => {
     if (hasShippingAddress) {
-      push("/mypage/address");
+      setIsPicking(!isPicking);
     } else {
       push("/mypage/address/new");
     }
   };
 
   return (
-    <div className="mb-12">
-      <div className="flex justify-between border-b pb-4 mb-5">
-        <h2 className="font-bold">배송 정보</h2>
-        {session && (
-          <Button onClick={handleShippingAddressChange} size="auto" className="text-xs px-2">
-            {hasShippingAddress ? "배송지 변경" : "배송지 추가"}
-          </Button>
-        )}
+    <div className="rounded-2xl border border-gray-200 bg-card p-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-[15px] font-bold">배송 정보</h2>
+        <Button
+          variant="plain"
+          size="auto"
+          onClick={handleShippingAddressChange}
+          className="rounded-full border border-gray-300 px-3 py-1 text-xs text-gray-500 hover:bg-gray-50"
+        >
+          {hasShippingAddress ? (isPicking ? "접기" : "변경") : "배송지 추가"}
+        </Button>
       </div>
-      <ul className="flex flex-col justify-between gap-2 text-sm">
-        {!hasShippingAddress ? (
-          <li className="flex items-center justify-center flex-col gap-1 my-8">
-            <h3>배송 정보가 없습니다.</h3>
-            <p>배송지를 추가해 주세요.</p>
+      {isPicking ? (
+        <ShippingAddressPicker userId={session.user.id} />
+      ) : !hasShippingAddress ? (
+        <div className="my-7 flex flex-col items-center gap-1 text-sm">
+          <h3>배송 정보가 없습니다.</h3>
+          <p className="text-[13px] text-gray-400">배송지를 추가해 주세요.</p>
+        </div>
+      ) : (
+        <ul className="mt-3.5 flex flex-col gap-2 text-[13px]">
+          <li className="flex">
+            <h3 className="w-[80px] shrink-0 text-gray-400">받는 분</h3>
+            <p>{shippingAddress?.recipient_name}</p>
           </li>
-        ) : (
-          <>
+          <li className="flex">
+            <h3 className="w-[80px] shrink-0 text-gray-400">휴대폰 번호</h3>
+            <p>{shippingAddress?.recipient_phone}</p>
+          </li>
+          <li className="flex">
+            <h3 className="w-[80px] shrink-0 text-gray-400">배송지 정보</h3>
+            <div className="min-w-0 leading-relaxed">
+              <span className="mr-1">({shippingAddress?.postal_code})</span>
+              <span className="mr-1">{shippingAddress?.address_line1}</span>
+              <span>{shippingAddress?.address_line2}</span>
+            </div>
+          </li>
+          {shippingAddress?.request && (
             <li className="flex">
-              <h3 className="w-[100px] text-gray-400">받는 분</h3>
-              <p className="flex-shrink-0">{shippingAddress?.recipient_name}</p>
+              <h3 className="w-[80px] shrink-0 text-gray-400">요청사항</h3>
+              <p className="min-w-0">{shippingAddress.request}</p>
             </li>
-            <li className="flex">
-              <h3 className="w-[100px] flex-shrink-0 text-gray-400">휴대폰 번호</h3>
-              <p>{shippingAddress?.recipient_phone}</p>
-            </li>
-            <li className="flex">
-              <h3 className="w-[100px] flex-shrink-0 text-gray-400">배송지 정보</h3>
-              <div>
-                <span className="mr-1">{shippingAddress?.postal_code}</span>
-                <span className="mr-1">{shippingAddress?.address_line1}</span>
-                <span>{shippingAddress?.address_line2}</span>
-              </div>
-            </li>
-            {shippingAddress?.request && (
-              <li className="flex">
-                <h3 className="w-[100px] flex-shrink-0 text-gray-400">요청사항</h3>
-                {shippingAddress.request}
-              </li>
-            )}
-          </>
-        )}
-      </ul>
+          )}
+        </ul>
+      )}
     </div>
   );
 };

--- a/src/components/cart/ShippingAddressPicker.tsx
+++ b/src/components/cart/ShippingAddressPicker.tsx
@@ -1,0 +1,92 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/hooks/use-toast";
+import { useShippingAddresses, useUpdateShippingAddress } from "@/hooks/queries/useShippingAddress";
+
+interface ShippingAddressPickerProps {
+  userId: string;
+}
+
+// 배송 정보 '변경' — 저장된 배송지 인라인 라디오 선택 (시안: 장바구니 · 정보 편집)
+const ShippingAddressPicker = ({ userId }: ShippingAddressPickerProps) => {
+  const { push } = useRouter();
+  const { data: addresses } = useShippingAddresses(userId);
+  const { mutate: updateAddress, isPending } = useUpdateShippingAddress();
+
+  //라디오 선택 = 기본 배송지 변경 (RPC가 나머지 기본 설정을 해제)
+  const handleSelect = (addressId: string, isDefault: boolean | null) => {
+    if (isDefault || isPending) return;
+
+    updateAddress(
+      { addressId, data: { is_default: true, user_id: userId } },
+      {
+        onSuccess: () => {
+          toast({
+            title: "기본 배송지가 변경되었습니다.",
+          });
+        },
+        onError: (error) => {
+          toast({
+            title: "배송지 변경에 실패했습니다.",
+            description: error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.",
+            variant: "destructive",
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="mt-3.5 flex flex-col gap-2.5">
+      {addresses?.map((address) => (
+        <button
+          key={address.id}
+          type="button"
+          onClick={() => handleSelect(address.id, address.is_default)}
+          disabled={isPending}
+          className={`flex items-start gap-3 rounded-xl border p-4 text-left transition-colors ${
+            address.is_default
+              ? "border-purple-300 bg-purple-50"
+              : "border-gray-200 hover:border-gray-300"
+          }`}
+        >
+          <span
+            className={`mt-0.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border-[1.5px] ${
+              address.is_default ? "border-purple-300" : "border-gray-300"
+            }`}
+            aria-hidden
+          >
+            {address.is_default && <span className="h-2 w-2 rounded-full bg-purple-300" />}
+          </span>
+          <span className="flex min-w-0 flex-col gap-1">
+            <span className="flex items-center gap-2">
+              <strong className="text-sm font-bold">{address.recipient_name}</strong>
+              {address.is_default && (
+                <span className="rounded-full bg-purple-300 px-2 py-0.5 text-[10px] font-bold text-white">
+                  기본 배송지
+                </span>
+              )}
+            </span>
+            <span className="text-[13px] text-gray-500">{address.recipient_phone}</span>
+            <span className="text-[13px] leading-relaxed text-gray-500">
+              ({address.postal_code}) {address.address_line1} {address.address_line2}
+            </span>
+          </span>
+        </button>
+      ))}
+      <Button
+        variant="plain"
+        size="auto"
+        onClick={() => push("/mypage/address/new")}
+        className="flex h-11 w-full items-center justify-center gap-1.5 rounded-full border border-gray-300 text-[13px] font-semibold text-gray-500 hover:bg-gray-50"
+      >
+        <Plus size={14} />새 배송지 추가
+      </Button>
+      <p className="text-center text-[11px] text-gray-400">배송지 추가·수정은 마이페이지 배송지 관리에서 진행돼요</p>
+    </div>
+  );
+};
+
+export default ShippingAddressPicker;

--- a/src/components/common/QuantitySelector.tsx
+++ b/src/components/common/QuantitySelector.tsx
@@ -1,34 +1,37 @@
 import { Button } from "@/components/ui/button";
-import { SquareMinus, SquarePlus } from "lucide-react";
+import { Minus, Plus } from "lucide-react";
+
 interface QuantitySelectorProps {
-  className: string;
+  className?: string;
   quantity: number;
   increase: () => void;
   decrease: () => void;
 }
 
-const QuantitySelector = ({ className, quantity, increase, decrease }: QuantitySelectorProps) => {
+// 상세 페이지(ProductInfo)와 동일한 필 스테퍼 — 시안 기준 카드 내 소형 사이즈
+const QuantitySelector = ({ className = "", quantity, increase, decrease }: QuantitySelectorProps) => {
   return (
-    <div className="flex items-center text-sm">
-      <h3 className={className}>수량</h3>
-      <div className="flex gap-2 items-center">
-        <Button variant="plain" size="auto"
-          onClick={decrease}
-          disabled={quantity === 1}
-          className={`${quantity === 1 ? "opacity-50 cursor-not-allowed" : "hover:text-purple"}`}
-          aria-label="수량 감소"
-        >
-          <SquareMinus size={25} />
-        </Button>
-        <p>{quantity}</p>
-        <Button variant="plain" size="auto"
-          onClick={increase}
-          className={`${quantity >= 5 ? "opacity-50 " : "hover:text-purple"}`}
-          aria-label="수량 증가"
-        >
-          <SquarePlus size={25} />
-        </Button>
-      </div>
+    <div className={`flex w-fit items-center rounded-full border border-gray-300 ${className}`}>
+      <Button
+        variant="plain"
+        size="auto"
+        onClick={decrease}
+        disabled={quantity === 1}
+        className="flex h-8 w-8 items-center justify-center text-gray-400 disabled:opacity-40"
+        aria-label="수량 감소"
+      >
+        <Minus size={13} />
+      </Button>
+      <span className="w-7 text-center text-[13px] font-bold">{quantity}</span>
+      <Button
+        variant="plain"
+        size="auto"
+        onClick={increase}
+        className="flex h-8 w-8 items-center justify-center"
+        aria-label="수량 증가"
+      >
+        <Plus size={13} />
+      </Button>
     </div>
   );
 };

--- a/src/components/common/loading/CartListLoading.tsx
+++ b/src/components/common/loading/CartListLoading.tsx
@@ -1,11 +1,31 @@
-import Spinner from "@/components/common/Spinner";
+import { Skeleton } from "@/components/ui/skeleton";
 
 const CartListLoading = () => {
   return (
-    <div className="flex-[2] p-5 lg:p-10 border rounded-md bg-card shadow-sm min-h-[500px] h-fit">
-      <h2 className="font-bold text-lg lg:text-xl">장바구니</h2>
-      <div className="w-full min-h-[500px] flex items-center justify-center">
-        <Spinner />
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center justify-between px-1 pb-1">
+        <Skeleton className="h-5 w-28" />
+        <div className="flex gap-2">
+          <Skeleton className="h-8 w-[74px] rounded-full" />
+          <Skeleton className="h-8 w-24 rounded-full" />
+        </div>
+      </div>
+      <div className="mt-3 flex flex-col gap-3.5">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="flex items-center gap-4 rounded-2xl border border-gray-200 bg-card p-5">
+            <Skeleton className="h-4 w-4 shrink-0" />
+            <Skeleton className="h-[88px] w-[88px] shrink-0 rounded-xl" />
+            <div className="flex min-w-0 flex-1 flex-col gap-2">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-8 w-24 rounded-full" />
+            </div>
+            <div className="flex shrink-0 flex-col items-end gap-1.5 pr-1 lg:pr-4">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-6 w-20" />
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/common/loading/CartSummarySkeleton.tsx
+++ b/src/components/common/loading/CartSummarySkeleton.tsx
@@ -2,81 +2,38 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 const CartSummarySkeleton = () => {
   return (
-    <div className="lg:sticky lg:top-5 flex-1 border rounded-md bg-card shadow-sm p-5 lg:p-10 h-fit">
-      <div className="mb-12">
-        <Skeleton className="h-7 w-24 mb-5" />
-        <div className="border-b pb-3 flex justify-between items-center">
-          <Skeleton className="h-7 w-20" />
-          <div className="flex items-center">
-            <Skeleton className="h-7 w-24 mr-1" />
-          </div>
+    <aside className="flex w-full flex-col gap-4 lg:sticky lg:top-24 lg:w-[400px] lg:shrink-0">
+      <div className="rounded-[20px] border border-gray-200 bg-card p-7">
+        <Skeleton className="h-6 w-20" />
+        <div className="mt-4 flex flex-col gap-2.5">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="flex items-center justify-between">
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+          ))}
         </div>
-        <div className="pt-5 mb-10">
-          <div className="mb-2 flex justify-between items-center">
-            <Skeleton className="h-5 w-16" />
+        <div className="mt-4 flex items-end justify-between border-t border-gray-200 pt-4">
+          <Skeleton className="h-5 w-20" />
+          <Skeleton className="h-8 w-28" />
+        </div>
+        <Skeleton className="mt-5 h-5 w-full" />
+        <Skeleton className="mt-5 h-14 w-full rounded-full" />
+      </div>
+      {Array.from({ length: 2 }).map((_, index) => (
+        <div key={index} className="rounded-2xl border border-gray-200 bg-card p-6">
+          <div className="flex items-center justify-between">
             <Skeleton className="h-5 w-20" />
+            <Skeleton className="h-6 w-12 rounded-full" />
           </div>
-          <div className="flex justify-between items-center">
-            <Skeleton className="h-5 w-20" />
-            <Skeleton className="h-5 w-20" />
-          </div>
-        </div>
-      </div>
-      <div className="mb-12">
-        <div className="border-b pb-3 flex justify-between items-center">
-          <Skeleton className="h-7 w-20" />
-          <div className="flex items-center">
-            <Skeleton className="h-7 w-24 mr-1" />
+          <div className="mt-4 flex flex-col gap-2">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-4 w-full" />
           </div>
         </div>
-        <div className="pt-5 mb-10">
-          <div className="mb-2 flex items-center gap-10">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-5 w-full" />
-          </div>
-          <div className="mb-2 flex items-center gap-10">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-5 w-full" />
-          </div>
-          <div className="mb-2 flex items-center gap-10">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-5 w-full" />
-          </div>
-        </div>
-      </div>
-      <div className="mb-12">
-        <div className="border-b pb-3 flex justify-between items-center">
-          <Skeleton className="h-7 w-32" />
-          <div className="flex items-center">
-            <Skeleton className="h-7 w-24 mr-1" />
-          </div>
-        </div>
-        <div className="pt-5 mb-10">
-          <div className="mb-2 flex items-center gap-10">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-5 w-full" />
-          </div>
-          <div className="mb-2 flex items-center gap-10">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-5 w-full" />
-          </div>
-          <div className="mb-2 flex items-center gap-10">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-5 w-full" />
-          </div>
-        </div>
-      </div>
-      <div className="mb-1">
-        <div className="border-b pb-3 flex justify-between items-center">
-          <Skeleton className="h-7 w-20" />
-        </div>
-        <div className="pt-5 mb-5">
-          <Skeleton className="mb-3 h-5 w-full" />
-          <Skeleton className="h-5 w-full" />
-        </div>
-      </div>
-      <Skeleton className="h-10 w-full rounded-md" />
-    </div>
+      ))}
+    </aside>
   );
 };
 

--- a/src/components/common/loading/PaymentSuccessLoading.tsx
+++ b/src/components/common/loading/PaymentSuccessLoading.tsx
@@ -1,10 +1,17 @@
+import { Info } from "lucide-react";
+import Spinner from "@/components/common/Spinner";
+
+// 결제 승인 확인 중 화면 — 시안: "결제 처리 중"
 const PaymentSuccessLoading = () => {
   return (
-    <div className="min-h-screen flex items-center justify-center sm:-mt-20 md:mt-0">
-      <div className="flex flex-col items-center gap-4">
-        <h2>결제 정보를 처리하고 있습니다...</h2>
-        <p className="text-sm text-gray-500">잠시만 기다려주세요.</p>
-      </div>
+    <div className="flex min-h-screen flex-col items-center justify-center px-5 sm:-mt-20 md:mt-0">
+      <Spinner size={52} />
+      <h2 className="mt-7 text-xl font-bold lg:text-[22px]">결제 정보를 처리하고 있어요</h2>
+      <p className="mt-2.5 text-[15px] text-gray-500">잠시만 기다려 주세요. 결제 승인을 확인하는 중이에요.</p>
+      <p className="mt-6 flex items-center gap-1.5 rounded-full bg-gray-100 px-3.5 py-1.5 text-xs text-gray-400">
+        <Info size={13} aria-hidden />
+        결제가 끝날 때까지 창을 닫지 말아 주세요
+      </p>
     </div>
   );
 };

--- a/src/components/common/loading/PaymentSuccessPageLoading.tsx
+++ b/src/components/common/loading/PaymentSuccessPageLoading.tsx
@@ -1,12 +1,8 @@
-import Spinner from "@/components/common/Spinner";
+import PaymentSuccessLoading from "./PaymentSuccessLoading";
 
+// Suspense fallback — 결제 처리 중 화면과 동일한 표시를 사용
 const PaymentSuccessPageLoading = () => {
-  return (
-    <div className="h-screen flex items-center justify-center flex-col sm:-mt-20 md:mt-0">
-      <h2 className="mb-5 font-bold">Loading...</h2>
-      <Spinner />
-    </div>
-  );
+  return <PaymentSuccessLoading />;
 };
 
 export default PaymentSuccessPageLoading;

--- a/src/components/common/select/SelectionControl.tsx
+++ b/src/components/common/select/SelectionControl.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useId, useState } from "react";
+import { Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import ConfirmModal from "../modal/ConfirmModal";
 
@@ -35,37 +36,43 @@ const SelectionControl = ({
   };
 
   return (
-    <div className="flex text-sm items-center justify-between mt-5 pb-5 border-b border-gray-300">
-      <label htmlFor={`selectAll-${id}`} className="cursor-pointer">
+    <div className="flex items-center justify-between px-1 pb-1 text-sm">
+      <label htmlFor={`selectAll-${id}`} className="flex cursor-pointer items-center gap-2">
         <input
           type="checkbox"
           id={`selectAll-${id}`}
-          className="mr-[6px] w-4 h-4 translate-y-[3px]"
           checked={selectedCount === totalItems}
           onChange={onSelectAll}
         />
-        전체선택 {selectedCount}/{totalItems}
+        <span className="font-semibold">전체선택</span>
+        <span className="text-gray-400">
+          {selectedCount}/{totalItems}
+        </span>
       </label>
       <div className="flex gap-2">
         <Button
-          variant="outlineBrand" size="auto"
-          className="px-2 py-1 border rounded-md text-xs lg:text-sm"
+          variant="plain"
+          size="auto"
+          className="rounded-full border border-gray-300 px-3.5 py-1.5 text-[13px] text-gray-500 hover:bg-gray-50"
           onClick={onDeleteSelected}
         >
           선택삭제
         </Button>
         <Button
+          variant="plain"
           size="auto"
-          className="px-2 py-1 rounded-md text-xs lg:text-sm"
+          className="flex items-center gap-1.5 rounded-full bg-[#e7242417] px-3.5 py-1.5 text-[13px] font-semibold text-[#E72424] hover:bg-[#e7242429]"
           onClick={handleDeleteAll}
         >
-          전체삭제
+          <Trash2 size={13} />
+          전체 비우기
         </Button>
       </div>
       {isModal && (
         <ConfirmModal
           isOpen={setIsModal}
           onConfirm={onConfirm}
+          variant="destructive"
           title={title}
           description={description}
           cancelText={cancelText}

--- a/src/components/layout/header/components/CartIcon.tsx
+++ b/src/components/layout/header/components/CartIcon.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useCartItems } from "@/store/zustand";
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import { ShoppingCart } from "lucide-react";
 interface CartIconProps {
   iconSize?: number;
@@ -16,9 +17,11 @@ const CartIcon = ({
   className = "",
 }: CartIconProps) => {
   const [mounted, setMounted] = useState(false);
+  const pathname = usePathname();
   const cartItems = useCartItems();
 
   const uniqueItemsCount = cartItems.length;
+  const isCartPage = pathname === "/cart";
 
   useEffect(() => {
     setMounted(true);
@@ -28,7 +31,10 @@ const CartIcon = ({
     <div className={linkClassName}>
       {/* w-fit: 뱃지가 아이콘 모서리에 정확히 겹치도록 래퍼를 아이콘 크기로 고정 */}
       <div className="relative w-fit">
-        <ShoppingCart className={`${iconClassName} cursor-pointer`} size={iconSize} />
+        <ShoppingCart
+          className={`${iconClassName} cursor-pointer ${isCartPage ? "text-purple-400" : ""}`}
+          size={iconSize}
+        />
         {mounted && uniqueItemsCount > 0 && (
           <span
             className={`${className} absolute -right-2 -top-1.5 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-orange-500 px-1 text-[10px] font-bold leading-none text-white`}

--- a/src/components/mypage/order/OrderPaymentDetails.tsx
+++ b/src/components/mypage/order/OrderPaymentDetails.tsx
@@ -4,20 +4,20 @@ import type { PaymentDetailsProps } from "@/types/mypage";
 const OrderPaymentDetails = ({ item }: PaymentDetailsProps) => {
   return (
     <>
-      <li>
-        <span className="text-gray-500 mr-1">결제 방법 :</span>
+      <li className="flex">
+        <span className="w-[80px] shrink-0 text-gray-400">결제 방법</span>
         <span>{item?.payment_method}</span>
       </li>
-      <li>
-        <span className="text-gray-500 mr-1">본인 납부 :</span>
+      <li className="flex">
+        <span className="w-[80px] shrink-0 text-gray-400">할부</span>
         <span>{Number(item?.installment_months) > 0 ? `${item?.installment_months}개월 할부` : "일시불"}</span>
       </li>
-      <li>
-        <span className="text-gray-500 mr-1">결제 일시 :</span>
+      <li className="flex">
+        <span className="w-[80px] shrink-0 text-gray-400">결제 일시</span>
         <span>{item?.created_at ? formatPaymentDate(item.created_at) : "-"}</span>
       </li>
-      <li>
-        <span className="text-gray-500 mr-1">주문 상태 :</span>
+      <li className="flex">
+        <span className="w-[80px] shrink-0 text-gray-400">주문 상태</span>
         <span>{item?.status}</span>
       </li>
     </>

--- a/src/components/mypage/order/OrderPaymentInfo.tsx
+++ b/src/components/mypage/order/OrderPaymentInfo.tsx
@@ -5,17 +5,18 @@ const OrderPaymentInfo = ({ item }: PaymentDetailsProps) => {
   return (
     <>
       <li className="flex justify-between">
-        <span className="text-gray-500">총 주문 금액 :</span>
-        <span>{formatPrice(Number(item?.amount))} 원</span>
+        <span className="text-gray-400">총 주문 금액</span>
+        <span className="font-semibold">{formatPrice(Number(item?.amount))}원</span>
       </li>
-      <li className="flex justify-between border-b pb-2">
-        <span className="text-gray-500">총 배송비 :</span>
-        {/* 추후 수정필요 */}
-        <span>0 원</span>
+      <li className="flex justify-between">
+        <span className="text-gray-400">배송비</span>
+        <span className="font-semibold">무료</span>
       </li>
-      <li className="flex justify-between font-medium items-center">
-        <span className="text-gray-500">총 결제 금액 :</span>
-        <span className="font-bold text-base">{formatPrice(Number(item?.amount))} 원</span>
+      <li className="flex items-end justify-between border-t border-gray-200 pt-2.5 font-medium">
+        <span className="text-gray-400">총 결제 금액</span>
+        <span className="text-base font-bold text-purple-500 dark:text-purple-300">
+          {formatPrice(Number(item?.amount))}원
+        </span>
       </li>
     </>
   );

--- a/src/components/mypage/order/PaymentOverview.tsx
+++ b/src/components/mypage/order/PaymentOverview.tsx
@@ -20,9 +20,9 @@ const PaymentOverview = ({ title, payment }: PaymentOverviewProps) => {
   const SelectedComponent = getComponent(title);
 
   return (
-    <div className="flex-1 border border-gray-200 rounded-lg px-4 py-5">
-      <h3 className="font-bold mb-4 border-b pb-2">{title}</h3>
-      <ul className="space-y-2 text-sm">{SelectedComponent && <SelectedComponent item={payment} />}</ul>
+    <div className="flex-1 rounded-2xl border border-gray-200 bg-card p-6">
+      <h3 className="text-[15px] font-bold">{title}</h3>
+      <ul className="mt-3.5 space-y-2 text-[13px]">{SelectedComponent && <SelectedComponent item={payment} />}</ul>
     </div>
   );
 };

--- a/src/components/mypage/order/RecipientInfo.tsx
+++ b/src/components/mypage/order/RecipientInfo.tsx
@@ -3,18 +3,18 @@ import type { PaymentDetailsProps } from "@/types/mypage";
 const RecipientInfo = ({ item }: PaymentDetailsProps) => {
   return (
     <>
-      <li>
-        <span className="flex-shrink-0 text-gray-500 mr-2">받는 분 :</span>
+      <li className="flex">
+        <span className="w-[80px] shrink-0 text-gray-400">받는 분</span>
         <span>{item?.recipient_name}</span>
       </li>
-      <li className="flex items-center gap-2">
-        <span className="text-gray-500">휴대폰 번호 :</span>
+      <li className="flex">
+        <span className="w-[80px] shrink-0 text-gray-400">휴대폰 번호</span>
         <span>{item?.recipient_phone}</span>
       </li>
-      <li className="flex items-stretch gap-2">
-        <span className="flex-shrink-0 text-gray-500">배송지 정보 :</span>
-        <span>
-          &#91;{item?.postal_code}&#93; {item?.address_line1}
+      <li className="flex">
+        <span className="w-[80px] shrink-0 text-gray-400">배송지 정보</span>
+        <span className="min-w-0 leading-relaxed">
+          ({item?.postal_code}) {item?.address_line1}
           {item?.address_line2}
         </span>
       </li>

--- a/src/components/payment/PaymentButton.tsx
+++ b/src/components/payment/PaymentButton.tsx
@@ -94,13 +94,11 @@ const PaymentButton = ({ amount, orderName }: PaymentButtonProps) => {
   return (
     <Button
       onClick={handlePayment}
+      variant="plain"
       size="auto"
-      className="flex items-baseline justify-center text-center w-full py-2"
+      className="mt-5 h-14 w-full rounded-full bg-gradient-to-r from-purple-400 to-orange-300 text-base font-bold text-white transition-opacity hover:opacity-90"
     >
-      <strong className="text-lg lg:text-xl mr-[2px]">
-        {formatPrice(amount)}
-      </strong>
-      원 결제하기
+      {formatPrice(amount)}원 결제하기
     </Button>
   );
 };

--- a/src/components/payment/success/OrderItemRow.tsx
+++ b/src/components/payment/success/OrderItemRow.tsx
@@ -1,0 +1,39 @@
+import Image from "next/image";
+import DefaultImage from "@/assets/images/default_image.avif";
+import { formatPrice, getDiscountedPrice } from "@/utils/calculateDiscount";
+import type { Tables } from "@/types/supabase";
+
+interface OrderItemRowProps {
+  item: Tables<"order_items">;
+}
+
+// 주문완료 화면의 주문상품 로우 (마이페이지 OrderListItem과 별개 — 시안 기준 컴팩트 로우)
+const OrderItemRow = ({ item }: OrderItemRowProps) => {
+  const price = getDiscountedPrice(item);
+  const optionText = [item.size && `사이즈 ${item.size}`, item.color && `색상 ${item.color}`]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <li className="flex items-center gap-3.5">
+      <Image
+        src={item.product_image || DefaultImage}
+        alt={item.product_name}
+        className="h-14 w-14 shrink-0 rounded-[10px] border border-gray-200 object-cover"
+        width={56}
+        height={56}
+      />
+      <div className="min-w-0 flex-1">
+        <h3 className="truncate text-sm font-bold">{item.product_name}</h3>
+        <p className="mt-0.5 text-[13px] uppercase text-gray-400">
+          {optionText && <span>{optionText}</span>}
+          {optionText && <span className="px-1.5 text-gray-300">|</span>}
+          <span>수량 {item.quantity}개</span>
+        </p>
+      </div>
+      <strong className="shrink-0 text-[15px] font-bold">{formatPrice(price * item.quantity)}원</strong>
+    </li>
+  );
+};
+
+export default OrderItemRow;

--- a/src/components/payment/success/OrderItemsList.tsx
+++ b/src/components/payment/success/OrderItemsList.tsx
@@ -1,21 +1,23 @@
-import OrderListItem from "@/components/mypage/order/OrderListItem";
+import OrderItemRow from "./OrderItemRow";
 import type { Tables } from "@/types/supabase";
 import type { OrderItemsListProps } from "@/types/payment";
 
 const OrderItemsList = ({ orderItems }: OrderItemsListProps) => {
   return (
-    <div className="border rounded-lg px-4 py-5 mb-8">
-      <h2 className="text-base lg:text-xl mb-8 border-b pb-4">
-        <strong>
-          <span>주문상품 정보</span>
-          <span className="inline-block -translate-y-[2px] px-2">|</span>
-          <span>총 {orderItems?.length}개</span>
-        </strong>
-      </h2>
+    <div className="rounded-2xl border border-gray-200 bg-card p-6 lg:p-7">
+      <div className="flex items-center justify-between">
+        <h2 className="flex items-end gap-2">
+          <strong className="text-base font-bold">주문상품</strong>
+          <span className="text-[13px] text-gray-400">총 {orderItems?.length}개</span>
+        </h2>
+        <span className="rounded-full bg-purple-50 px-2.5 py-1 text-[11px] font-bold text-purple-500 dark:text-purple-300">
+          결제 완료
+        </span>
+      </div>
       {orderItems && orderItems.length > 0 && (
-        <ul className="flex flex-col w-full">
+        <ul className="mt-5 flex flex-col gap-4">
           {orderItems.map((item: Tables<"order_items">) => (
-            <OrderListItem key={item.id} item={item} />
+            <OrderItemRow key={item.id} item={item} />
           ))}
         </ul>
       )}

--- a/src/components/payment/success/PaymentSuccessHeader.tsx
+++ b/src/components/payment/success/PaymentSuccessHeader.tsx
@@ -1,5 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
+import { Check, Copy } from "lucide-react";
+import CheckoutSteps from "@/components/cart/CheckoutSteps";
+import { toast } from "@/hooks/use-toast";
 import type { PaymentSuccessHeaderProps } from "@/types/payment";
 
 const PaymentSuccessHeader = ({ orderId }: PaymentSuccessHeaderProps) => {
@@ -13,19 +16,59 @@ const PaymentSuccessHeader = ({ orderId }: PaymentSuccessHeaderProps) => {
     push("/shop");
   };
 
+  //주문번호 복사
+  const onClickCopyOrderId = async () => {
+    if (!orderId) return;
+    try {
+      await navigator.clipboard.writeText(orderId);
+      toast({
+        title: "주문번호를 복사했어요.",
+      });
+    } catch {
+      toast({
+        title: "주문번호 복사에 실패했습니다.",
+        variant: "destructive",
+      });
+    }
+  };
+
   return (
-    <div className="flex flex-col gap-4 items-center mb-10">
-      <h2 className="font-bold text-lg lg:text-xl">주문이 완료되었습니다.</h2>
-      <h3 className="text-gray-500">주문번호 : {orderId}</h3>
-      <div className="flex gap-3">
+    <div className="flex flex-col items-center">
+      <CheckoutSteps current={3} />
+      <span
+        className="mt-9 flex h-[72px] w-[72px] items-center justify-center rounded-full bg-gradient-to-r from-purple-400 to-orange-300"
+        aria-hidden
+      >
+        <Check size={34} strokeWidth={3} className="text-white" />
+      </span>
+      <h2 className="mt-5 text-2xl font-bold lg:text-[28px]">주문이 완료되었어요!</h2>
+      <p className="mt-2.5 text-[15px] text-gray-500">주문하신 굿즈를 정성껏 포장해서 보내드릴게요</p>
+      <Button
+        variant="plain"
+        size="auto"
+        onClick={onClickCopyOrderId}
+        className="mt-4 flex items-center gap-2 rounded-full bg-gray-100 px-4 py-2 text-[13px] hover:bg-gray-200"
+        aria-label="주문번호 복사"
+      >
+        <span className="text-gray-400">주문번호</span>
+        <strong className="font-semibold">{orderId}</strong>
+        <Copy size={13} className="text-gray-400" />
+      </Button>
+      <div className="mt-6 flex gap-2.5">
         <Button
           onClick={onClickGoOrders}
-          variant="outline" size="auto"
-          className="px-6 py-2 hover:bg-gray-50 hover:text-primary text-sm"
+          variant="plain"
+          size="auto"
+          className="h-12 rounded-full border border-gray-300 px-7 text-sm font-semibold text-gray-500 hover:bg-gray-50"
         >
           주문상세 보기
         </Button>
-        <Button onClick={onClickGoCart} size="auto" className="px-6 py-2 text-sm">
+        <Button
+          onClick={onClickGoCart}
+          variant="plain"
+          size="auto"
+          className="h-12 rounded-full bg-purple-300 px-7 text-sm font-bold text-white transition-colors hover:bg-purple-400"
+        >
           쇼핑 계속하기
         </Button>
       </div>

--- a/src/components/payment/success/PaymentSuccessView.tsx
+++ b/src/components/payment/success/PaymentSuccessView.tsx
@@ -5,11 +5,13 @@ import type { PaymentSuccessViewProps } from "@/types/payment";
 
 const PaymentSuccessView = ({ orderItems, payment }: PaymentSuccessViewProps) => {
   return (
-    <section className="px-5 pt-14 pb-28 lg:px-8 min-h-screen flex items-center justify-center">
-      <div className="max-w-container w-full m-auto flex flex-col gap-5">
+    <section className="px-5 pb-28 pt-12 lg:px-8">
+      <div className="mx-auto flex w-full max-w-[1000px] flex-col gap-5">
         <PaymentSuccessHeader orderId={payment.order_id} />
-        <OrderItemsList orderItems={orderItems} />
-        <div className="flex flex-col lg:flex-row gap-6">
+        <div className="mt-5">
+          <OrderItemsList orderItems={orderItems} />
+        </div>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
           <PaymentOverview title="배송 정보" payment={payment} />
           <PaymentOverview title="결제 정보" payment={payment} />
           <PaymentOverview title="결제 수단" payment={payment} />


### PR DESCRIPTION
## 요약
- **장바구니**(/cart): SHOPPING CART 헤드 + 진행 단계(01 장바구니 → 02 주문·결제 → 03 주문완료), 상품별 개별 카드 리스트(보라 체크박스·88px 썸네일·필 스테퍼·할인가 위계), 무료배송 안내 스트립, 빈 상태 리디자인
- **툴바**: 선택삭제(중립 아웃라인·즉시 삭제+토스트) / 전체 비우기(레드 틴트+휴지통 아이콘 → destructive ConfirmModal)
- **주문 요약 3분할**: 결제 금액 카드(총액 보라 강조·동의 1줄 압축(약관 보기 토글)·그라데이션 결제 CTA) + 주문자 정보(카드 내 인라인 폼) + 배송 정보(저장 배송지 라디오 인라인 선택 — 기본 배송지 뱃지, 새 배송지 추가)
- **헤더**: /cart에서 카트 아이콘 활성 보라
- **결제 처리 중**: 스피너 + 안내 카피 + "창을 닫지 말아 주세요" 칩
- **주문완료**(/payment/success): 단계 완료 인디케이터 + 그라데이션 체크 서클 + 주문번호 복사 칩 + 주문상품/배송/결제 정보/결제 수단 카드
- 로딩 스켈레톤 새 레이아웃 반영, e2e 카피 갱신

## 검증
- `tsc --noEmit` / `next lint` 통과 (에러 0)
- Playwright e2e 5건 통과 (cart · cart-actions · payment-guard, 프로드 빌드 포함)
- 브라우저 시안 대조 검수 완료 — 라이트/다크, 빈 상태, 비우기 모달, 주문자 인라인 폼, 배송지 라디오 전환+토스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)