### PR TITLE
fix: 히어로 배경 영상이 반복 접속 시 안 뜨던 문제 해결

### DIFF
--- a/src/components/main/VisualSection.tsx
+++ b/src/components/main/VisualSection.tsx
@@ -1,24 +1,131 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { ChevronDown, Volume2, VolumeX } from "lucide-react";
+import { ChevronDown } from "lucide-react";
+import type { YouTubePlayer } from "@/types/main";
 
 interface VisualSectionProps {
   videoId: string | null;
 }
 
+//재생 실패 시 새 플레이어로 다시 붙이는 횟수 상한 — 넘으면 썸네일 폴백을 그대로 둔다
+const MAX_RETRY = 3;
+//플레이어를 만든 뒤 실제 재생이 시작될 때까지 기다리는 시간
+const BOOT_TIMEOUT_MS = 7000;
+
+//IFrame API 스크립트는 문서당 한 번만 로드해 모든 호출이 같은 Promise를 공유한다
+let iframeApiPromise: Promise<void> | null = null;
+
+const loadIframeApi = () => {
+  if (iframeApiPromise) return iframeApiPromise;
+
+  iframeApiPromise = new Promise<void>((resolve, reject) => {
+    if (window.YT?.Player) {
+      resolve();
+      return;
+    }
+
+    //API는 준비되면 전역 콜백을 호출한다 — 기존 콜백이 있으면 함께 살려둔다
+    const previous = window.onYouTubeIframeAPIReady;
+    window.onYouTubeIframeAPIReady = () => {
+      previous?.();
+      resolve();
+    };
+
+    const script = document.createElement("script");
+    script.src = "https://www.youtube.com/iframe_api";
+    script.async = true;
+    script.onerror = () => {
+      iframeApiPromise = null;
+      reject(new Error("유튜브 IFrame API 로드 실패"));
+    };
+    document.head.appendChild(script);
+  });
+
+  return iframeApiPromise;
+};
+
 //유튜브 최신 공식 영상을 배경으로 자동 재생하는 비주얼 히어로
 const VisualSection = ({ videoId }: VisualSectionProps) => {
-  const [muted, setMuted] = useState(true);
+  const hostRef = useRef<HTMLDivElement>(null);
+  const playerRef = useRef<YouTubePlayer | null>(null);
 
-  const embedUrl = videoId
-    ? `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&mute=${muted ? 1 : 0}&controls=0&loop=1&playlist=${videoId}&modestbranding=1&rel=0&playsinline=1&disablekb=1`
-    : null;
+  //쿠키 없는 youtube-nocookie 임베드는 반복 접속 시 봇으로 걸려 플레이어가 부팅되지 않는다.
+  //www.youtube.com + origin으로 붙이고, 재생이 시작되지 않으면 IFrame API 이벤트로 감지해 재시도한다.
+  useEffect(() => {
+    if (!videoId) return;
+
+    let cancelled = false;
+    let attempt = 0;
+    let bootTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const teardown = () => {
+      clearTimeout(bootTimer);
+      playerRef.current?.destroy();
+      playerRef.current = null;
+    };
+
+    const retry = () => {
+      if (cancelled || attempt >= MAX_RETRY) return;
+      attempt += 1;
+      teardown();
+      void createPlayer();
+    };
+
+    const createPlayer = async () => {
+      try {
+        await loadIframeApi();
+      } catch {
+        return; //스크립트 자체가 막히면 썸네일 폴백 유지
+      }
+      if (cancelled || !hostRef.current || !window.YT) return;
+
+      //Player 생성자가 대상 엘리먼트를 iframe으로 통째로 치환하므로 시도마다 새 마운트 지점을 깐다
+      const mount = document.createElement("div");
+      hostRef.current.replaceChildren(mount);
+
+      bootTimer = setTimeout(retry, BOOT_TIMEOUT_MS);
+
+      playerRef.current = new window.YT.Player(mount, {
+        videoId,
+        host: "https://www.youtube.com",
+        playerVars: {
+          autoplay: 1,
+          mute: 1,
+          controls: 0,
+          loop: 1,
+          playlist: videoId,
+          modestbranding: 1,
+          rel: 0,
+          playsinline: 1,
+          disablekb: 1,
+          origin: window.location.origin,
+        },
+        events: {
+          onReady: (event) => event.target.playVideo(),
+          onStateChange: (event) => {
+            if (event.data === window.YT?.PlayerState.PLAYING) clearTimeout(bootTimer);
+          },
+          onError: () => {
+            clearTimeout(bootTimer);
+            retry();
+          },
+        },
+      });
+    };
+
+    void createPlayer();
+
+    return () => {
+      cancelled = true;
+      teardown();
+    };
+  }, [videoId]);
 
   return (
     <section className="h-[100dvh] lg:h-screen w-full relative overflow-hidden bg-gray-900 flex items-center justify-center">
-      {embedUrl ? (
+      {videoId ? (
         <>
           {/* 영상 로드 전·실패 시 폴백 — 유튜브 썸네일이 항상 밑레이어에 깔린다 */}
           <Image
@@ -29,14 +136,10 @@ const VisualSection = ({ videoId }: VisualSectionProps) => {
             className="object-cover"
             aria-hidden="true"
           />
-          <iframe
-            key={String(muted)}
-            src={embedUrl}
-            title="IVE 공식 최신 영상"
+          <div
+            ref={hostRef}
             aria-hidden="true"
-            tabIndex={-1}
-            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[max(100vw,177.78vh)] h-[max(100vh,56.25vw)] pointer-events-none"
-            allow="autoplay; encrypted-media"
+            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[max(100vw,177.78vh)] h-[max(100vh,56.25vw)] pointer-events-none [&>iframe]:w-full [&>iframe]:h-full"
           />
         </>
       ) : (
@@ -73,16 +176,6 @@ const VisualSection = ({ videoId }: VisualSectionProps) => {
         </div>
         <ChevronDown className="w-6 h-6 text-white/50 mt-8 animate-bounce" aria-hidden="true" />
       </div>
-
-      {videoId && (
-        <button
-          onClick={() => setMuted((prev) => !prev)}
-          aria-label={muted ? "배경 영상 소리 켜기" : "배경 영상 소리 끄기"}
-          className="absolute bottom-10 right-5 lg:right-10 flex items-center justify-center w-11 h-11 rounded-full bg-black/40 backdrop-blur-sm text-white hover:bg-black/60 transition-colors"
-        >
-          {muted ? <VolumeX className="w-5 h-5" /> : <Volume2 className="w-5 h-5" />}
-        </button>
-      )}
 
       <div
         className="absolute bottom-0 left-0 right-0 h-40 bg-gradient-to-b from-transparent to-[#0A0A0A]"

--- a/src/types/main/index.ts
+++ b/src/types/main/index.ts
@@ -15,3 +15,35 @@ export interface AlbumTrackListProps {
   /** 재생 시작 시 플레이어 바를 펼칠지 — 시트 안에서는 false로 미니 디스크 유지 (기본 true) */
   expandPlayerOnPlay?: boolean;
 }
+
+//유튜브 IFrame Player API — 히어로 배경 영상 제어에 필요한 부분만 선언 (@types/youtube 미설치)
+export interface YouTubePlayer {
+  playVideo: () => void;
+  destroy: () => void;
+}
+
+interface YouTubePlayerEvent {
+  target: YouTubePlayer;
+  data: number;
+}
+
+interface YouTubePlayerOptions {
+  videoId: string;
+  host?: string;
+  playerVars?: Record<string, string | number>;
+  events?: {
+    onReady?: (event: YouTubePlayerEvent) => void;
+    onStateChange?: (event: YouTubePlayerEvent) => void;
+    onError?: (event: YouTubePlayerEvent) => void;
+  };
+}
+
+declare global {
+  interface Window {
+    YT?: {
+      Player: new (el: HTMLElement, options: YouTubePlayerOptions) => YouTubePlayer;
+      PlayerState: { PLAYING: number };
+    };
+    onYouTubeIframeAPIReady?: () => void;
+  }
+}


### PR DESCRIPTION
## 문제

메인 히어로의 유튜브 공식 영상이 자주 접속하면 재생되지 않고, 밑레이어에 깔아둔 유튜브 썸네일만 노출됐다.

## 원인

Vercel·피드 문제가 아니었다. 프로덕션 HTML에는 iframe이 항상 들어있고 videoId도 `playableInEmbed: true`로 정상이었다. 문제는 클라이언트 쪽으로, **세션 쿠키가 없는 `youtube-nocookie.com` 임베드가 반복 로드에서 봇 판정에 걸려 플레이어가 부팅되지 않는 것**이었다. 그 결과 iframe이 비어 있는 채로 남아 아래 썸네일이 그대로 비쳐 보였다.

## 변경

- 직접 `<iframe>` → **IFrame Player API**로 `www.youtube.com` 호스트 + `origin` 파라미터를 지정해 클라이언트에서 생성
- **재생 실패 자동 복구** — `onError` 발생 시, 또는 7초 안에 `PLAYING` 상태에 도달하지 못하면 플레이어를 새로 붙여 최대 3회 재시도. 3회 모두 실패하면 기존처럼 썸네일 폴백 유지
- 히어로는 순수 배경 영상이므로 **음소거 토글 버튼과 관련 상태 제거** (항상 무음). 덤으로 소리 켤 때 `key`로 iframe을 리마운트해 재생이 처음부터 끊기던 것과, 브라우저의 소리 있는 autoplay 차단도 함께 해소
- `@types/youtube` 미설치라 `src/types/main`에 필요한 부분만 타입 선언 추가

영상 소스는 그대로 유튜브 공식 임베드 — 자체 호스팅(저작권 문제)은 채택하지 않았다.

## 검증

- `tsc --noEmit` · ESLint · `next build` · 로컬 프로덕션 서빙 통과
- 재생 실패 재시도가 실제로 동작하는지는 반복 로드가 쌓여야 재현되므로, 배포 후 프로덕션에서 새로고침 반복으로 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)