### PR TITLE
fix: 디스코그래피 메타데이터 브랜드 표기 통일

### DIFF
--- a/src/app/discography/page.tsx
+++ b/src/app/discography/page.tsx
@@ -1,12 +1,9 @@
-import type { Metadata } from "next";
 import DiscographyList from "@/components/discography/DiscographyList";
 import GoTopButton from "@/components/common/button/GoTopButton";
 import { fetchItunesReleases } from "@/lib/album/sync";
+import { discographyMetadata } from "@/metadata/discography/discographyMetadata";
 
-export const metadata: Metadata = {
-  title: "디스코그래피 - IVE로 DIVE",
-  description: "아이브(IVE)의 정규·미니·싱글 전체 발매 목록과 수록곡 미리듣기",
-};
+export const metadata = discographyMetadata;
 export const revalidate = 86400;
 
 const page = async () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,10 +12,10 @@ import ThemeBridge from "@/components/common/ThemeBridge";
 import AlbumPlayerBar from "@/components/main/AlbumPlayerBar";
 
 export const metadata: Metadata = {
-  title: "IVE-DIVE",
+  title: "IVE DIVE",
   description: "IVE 팬페이지 입니다.",
   openGraph: {
-    title: "IVE-DIVE",
+    title: "IVE DIVE",
     description: "IVE 팬페이지 입니다.",
     images: [
       "https://res.cloudinary.com/dknj7kdek/image/upload/v1737888335/og_nb8ueg.png",

--- a/src/metadata/discography/discographyMetadata.ts
+++ b/src/metadata/discography/discographyMetadata.ts
@@ -1,0 +1,12 @@
+export const discographyMetadata = {
+  title: "디스코그래피 - IVE DIVE",
+  description: "아이브(IVE)의 정규·미니·싱글 전체 발매 목록과 수록곡 미리듣기",
+  openGraph: {
+    title: "디스코그래피 - IVE DIVE",
+    description: "아이브(IVE)의 정규·미니·싱글 전체 발매 목록과 수록곡 미리듣기",
+    images: [
+      "https://res.cloudinary.com/dknj7kdek/image/upload/v1737888335/og_nb8ueg.png",
+    ],
+    type: "website",
+  },
+};


### PR DESCRIPTION
## 문제

`/discography`만 타이틀이 `디스코그래피 - IVE로 DIVE`로, 나머지 전 페이지가 쓰는 `... - IVE DIVE` 표기와 어긋나 있었다. 추가로 이 페이지만 메타데이터를 `page.tsx`에 인라인으로 정의하고 있었고 `openGraph` 블록도 빠져 있어서 공유 시 OG 타이틀·이미지가 나가지 않았다.

## 변경

- `src/metadata/discography/discographyMetadata.ts` 신설 — 다른 페이지(`newsMetadata`, `shopMetadata` 등)와 동일한 구조로 맞추고, `page.tsx`는 import만 하도록 변경
- 타이틀 `디스코그래피 - IVE로 DIVE` → **`디스코그래피 - IVE DIVE`**
- `openGraph`(title · description · images · type) 추가 — 기존 누락분
- 루트 레이아웃 기본 타이틀도 `IVE-DIVE`(하이픈) → **`IVE DIVE`** 로 통일

설명문은 기존의 구체적인 문구("아이브(IVE)의 정규·미니·싱글 전체 발매 목록과 수록곡 미리듣기")를 그대로 유지했다 — 다른 페이지의 보일러플레이트 문구보다 SEO상 낫다.

## 남겨둔 것

- `src/app/manifest.ts`의 `name` / `short_name`이 `IVE-DIVE`인데, 이건 PWA 설치 이름이라 하이브리드 앱에 영향이 갈 수 있어 건드리지 않았다. 같이 맞출지는 별도 판단 필요.
- `Footer.tsx` · Storybook 문서의 "IVE로 DIVE"는 서비스 한글 명칭 본문이라 그대로 뒀다.

## 검증

- `tsc --noEmit` · ESLint · `next build` 통과
- 빌드 산출물 확인 — `<title>디스코그래피 - IVE DIVE</title>`, `og:title` 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)