### PR TITLE
fix: PWA 매니페스트·푸시 알림 제목도 IVE DIVE로 통일

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -19,7 +19,7 @@ self.addEventListener("push", (event) => {
   }
 
   event.waitUntil(
-    self.registration.showNotification(payload.title ?? "IVE-DIVE", {
+    self.registration.showNotification(payload.title ?? "IVE DIVE", {
       body: payload.body ?? "",
       icon: "/images/app-icon-192.png",
       badge: "/images/app-icon-192.png",

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -3,8 +3,8 @@ import type { MetadataRoute } from "next";
 //PWA 매니페스트 — 홈 화면 설치 지원 (iOS 사파리는 설치된 PWA에서만 웹 푸시 수신 가능)
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "IVE-DIVE",
-    short_name: "IVE-DIVE",
+    name: "IVE DIVE",
+    short_name: "IVE DIVE",
     description: "IVE 팬페이지 입니다.",
     start_url: "/",
     display: "standalone",


### PR DESCRIPTION
## 배경

#154 에서 페이지 메타데이터를 `IVE DIVE`로 통일하면서 뒤로 미뤄뒀던 하이픈 표기(`IVE-DIVE`)를 마저 정리했다. 하이브리드 앱 `ive-app/app.json`의 `name`이 이미 `"IVE DIVE"`라 오히려 이쪽을 맞추는 게 앱-웹 표기가 일치한다.

## 변경

| 파일 | 변경 | 노출되는 곳 |
|---|---|---|
| `src/app/manifest.ts` | `name` · `short_name` → `IVE DIVE` | PWA 홈 화면 설치 아이콘 이름 |
| `public/sw.js` | 웹 푸시 기본 제목 → `IVE DIVE` | `payload.title` 없을 때의 알림 제목 |

이걸로 `src/`·`public/` 전체에 `IVE-DIVE` 표기 0건.

`Footer.tsx`와 Storybook 문서의 "IVE로 DIVE"는 서비스 한글 명칭 본문이라 그대로 뒀다.

## 검증

- `grep -rn "IVE-DIVE" src/ public/` → 0건
- `tsc --noEmit` · ESLint · `next build` 통과
- 빌드 산출물 `manifest.webmanifest` 확인 — `"name":"IVE DIVE"`, `"short_name":"IVE DIVE"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)