### PR TITLE
perf: 히어로 영상 호스트 preconnect 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,9 @@ export default function RootLayout({
         <link rel="preconnect" href="https://supabase.co" />
         <link rel="preconnect" href="https://kakaocdn.net" />
         <link rel="preconnect" href="https://img1.kakaocdn.net" />
+        {/* 히어로 배경 영상 — 썸네일(i.ytimg)과 IFrame API·임베드(www.youtube)의 연결을 미리 열어둔다 */}
+        <link rel="preconnect" href="https://i.ytimg.com" />
+        <link rel="preconnect" href="https://www.youtube.com" />
       </head>
       <body className={`${pretendard.className} w-screen overflow-x-hidden`}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>


### PR DESCRIPTION
## 배경

#152 에서 히어로 영상을 SSR iframe → IFrame Player API(클라이언트 생성)로 바꾸면서, 영상이 하이드레이션 이후에 붙게 됐다. 페이지 자체의 초기 로딩은 오히려 가벼워졌지만(임베드가 더 이상 임계 경로에서 대역폭·CPU를 뺏지 않는다) **영상 재생 시작 시점은 한 단계 늦어졌다.**

## 변경

`layout.tsx`의 기존 preconnect 목록에 두 줄 추가 — 연결 수립(DNS + TLS)을 미리 끝내둬 그만큼 앞당긴다.

- `https://i.ytimg.com` — 히어로에서 **실제로 먼저 보이는 썸네일** 호스트 (`priority` 이미지)
- `https://www.youtube.com` — IFrame API 스크립트와 임베드 문서 호스트

영상 세그먼트가 오는 `*.googlevideo.com`은 서브도메인이 동적이라 preconnect 대상이 못 된다.

## 검증

- `tsc --noEmit` · ESLint · `next build` 통과
- 빌드 산출물 `index.html`에 두 preconnect가 렌더된 것 확인

실제 개선 폭은 브라우저 실측을 못 해 수치로 제시하지 못한다 — 연결 수립 시간만큼(보통 100~300ms) 앞당겨지는 성격의 변경이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)