### PR TITLE
fix: 히어로 영상 자막 노출·초기 검은 화면·과민한 재시도 수정

### DIFF
--- a/src/components/main/VisualSection.tsx
+++ b/src/components/main/VisualSection.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { ChevronDown } from "lucide-react";
+import { cn } from "@/utils/utils";
 import type { YouTubePlayer } from "@/types/main";
 
 interface VisualSectionProps {
@@ -11,8 +12,19 @@ interface VisualSectionProps {
 
 //재생 실패 시 새 플레이어로 다시 붙이는 횟수 상한 — 넘으면 썸네일 폴백을 그대로 둔다
 const MAX_RETRY = 3;
-//플레이어를 만든 뒤 실제 재생이 시작될 때까지 기다리는 시간
-const BOOT_TIMEOUT_MS = 7000;
+//플레이어를 만든 뒤 재생이 시작될 때까지 기다리는 시간 — 짧게 잡으면 느릴 뿐인 플레이어를
+//죽이고 처음부터 다시 붙이느라 재생이 오히려 늦어진다(실측 1차 시도가 7초를 넘기는 경우가 있었다)
+const BOOT_TIMEOUT_MS = 12000;
+//버퍼링은 "막힘"이 아니라 진행 신호라 타이머를 이만큼 연장한다. 버퍼링이 반복되면 계속
+//연장되지만, 그건 플레이어가 살아 있다는 뜻이라 죽이지 않는 편이 낫다
+const BUFFER_GRACE_MS = 10000;
+
+//배경 장식 영상이라 자막을 끈다. playerVars의 cc_load_policy만으로는 시청자 기본 설정을 못 이기고,
+//onReady 시점엔 캡션 모듈이 아직 로드 전이라 먹지 않는다 — 재생이 시작된 뒤에도 한 번 더 호출한다
+const disableCaptions = (player: YouTubePlayer) => {
+  player.unloadModule("captions");
+  player.unloadModule("cc");
+};
 
 //IFrame API 스크립트는 문서당 한 번만 로드해 모든 호출이 같은 Promise를 공유한다
 let iframeApiPromise: Promise<void> | null = null;
@@ -48,6 +60,9 @@ const loadIframeApi = () => {
 
 //유튜브 최신 공식 영상을 배경으로 자동 재생하는 비주얼 히어로
 const VisualSection = ({ videoId }: VisualSectionProps) => {
+  //재생이 실제로 시작되기 전까지 iframe을 투명하게 둔다 — 유튜브 플레이어가 자기 검은 배경을
+  //깔아버려서, 그대로 두면 밑레이어의 썸네일 폴백이 정작 필요한 순간에 가려진다
+  const [playing, setPlaying] = useState(false);
   const hostRef = useRef<HTMLDivElement>(null);
   const playerRef = useRef<YouTubePlayer | null>(null);
 
@@ -69,6 +84,7 @@ const VisualSection = ({ videoId }: VisualSectionProps) => {
     const retry = () => {
       if (cancelled || attempt >= MAX_RETRY) return;
       attempt += 1;
+      setPlaying(false);
       teardown();
       void createPlayer();
     };
@@ -100,12 +116,26 @@ const VisualSection = ({ videoId }: VisualSectionProps) => {
           rel: 0,
           playsinline: 1,
           disablekb: 1,
+          cc_load_policy: 0,
+          iv_load_policy: 3,
           origin: window.location.origin,
         },
         events: {
-          onReady: (event) => event.target.playVideo(),
+          onReady: (event) => {
+            disableCaptions(event.target);
+            event.target.playVideo();
+          },
           onStateChange: (event) => {
-            if (event.data === window.YT?.PlayerState.PLAYING) clearTimeout(bootTimer);
+            if (event.data === window.YT?.PlayerState.PLAYING) {
+              clearTimeout(bootTimer);
+              disableCaptions(event.target);
+              setPlaying(true);
+              return;
+            }
+            if (event.data === window.YT?.PlayerState.BUFFERING) {
+              clearTimeout(bootTimer);
+              bootTimer = setTimeout(retry, BUFFER_GRACE_MS);
+            }
           },
           onError: () => {
             clearTimeout(bootTimer);
@@ -139,7 +169,10 @@ const VisualSection = ({ videoId }: VisualSectionProps) => {
           <div
             ref={hostRef}
             aria-hidden="true"
-            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[max(100vw,177.78vh)] h-[max(100vh,56.25vw)] pointer-events-none [&>iframe]:w-full [&>iframe]:h-full"
+            className={cn(
+              "absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[max(100vw,177.78vh)] h-[max(100vh,56.25vw)] pointer-events-none transition-opacity duration-700 [&>iframe]:w-full [&>iframe]:h-full",
+              playing ? "opacity-100" : "opacity-0"
+            )}
           />
         </>
       ) : (

--- a/src/types/main/index.ts
+++ b/src/types/main/index.ts
@@ -19,6 +19,7 @@ export interface AlbumTrackListProps {
 //유튜브 IFrame Player API — 히어로 배경 영상 제어에 필요한 부분만 선언 (@types/youtube 미설치)
 export interface YouTubePlayer {
   playVideo: () => void;
+  unloadModule: (module: string) => void;
   destroy: () => void;
 }
 
@@ -42,7 +43,7 @@ declare global {
   interface Window {
     YT?: {
       Player: new (el: HTMLElement, options: YouTubePlayerOptions) => YouTubePlayer;
-      PlayerState: { PLAYING: number };
+      PlayerState: { PLAYING: number; BUFFERING: number };
     };
     onYouTubeIframeAPIReady?: () => void;
   }


### PR DESCRIPTION
## 배경

#152 · #158 배포 후 **프로덕션을 Chrome으로 실측**해서 찾은 문제 3가지다. 리소스 타임라인은 이랬다.

```
i.ytimg.com/…/maxresdefault.jpg    41ms  (28ms 완료)
www.youtube.com/iframe_api        711ms
www.youtube.com/embed/kX7PD3NzYw8  1089ms   ← 1차 시도
www.youtube.com/embed/kX7PD3NzYw8  8217ms   ← 재시도 발동
```

## 1. 유튜브 자막이 켜진 채 재생됨

배경 장식 영상인데 하단에 자막 박스가 떴다. `playerVars.cc_load_policy`만으로는 시청자 기본 설정을 못 이기고, `onReady` 시점엔 **캡션 모듈이 아직 로드 전**이라 `unloadModule`이 먹지 않는다.

→ `disableCaptions()` 헬퍼를 만들어 `onReady`와 **`PLAYING` 도달 시점 두 번** 호출. `iv_load_policy: 3`으로 주석 오버레이도 함께 껐다.

## 2. 재생 시작 전 8~16초간 새까만 화면

썸네일은 41ms에 이미 로드돼 있는데, 1089ms에 iframe이 붙으면서 **유튜브 플레이어의 검은 배경이 밑레이어 썸네일을 덮어버린다.** 폴백이 정작 필요한 순간에 가려지는 구조였다.

→ `PLAYING` 도달 전까지 iframe을 `opacity-0`으로 두고 페이드인(0.7초). 그동안 썸네일이 그대로 보인다.

## 3. 부팅 타임아웃 7초가 너무 공격적

위 타임라인의 8217ms 재요청이 재시도다. 1차 시도는 **막힌 게 아니라 그냥 느렸을 뿐**인데 타이머가 죽이고 처음부터 다시 붙여 재생을 오히려 늦췄다.

→ `BOOT_TIMEOUT_MS` 7초 → **12초**, `BUFFERING`은 진행 신호로 보아 타이머를 `BUFFER_GRACE_MS`(10초)로 연장. 버퍼링이 반복되면 계속 연장되지만, 그건 플레이어가 살아 있다는 뜻이라 죽이지 않는 편이 낫다.

## 검증

로컬 프로덕션 빌드를 Chrome으로 직접 확인 —

- **embed 요청 1회** (수정 전 프로덕션은 2회) → 재시도 미발동
- 자막 박스 사라짐 (남아 있는 문구는 영상에 구워진 자체 그래픽이라 제어 대상 아님)
- 2초 시점에 이미 영상, 검은 화면 구간 없음
- `tsc --noEmit` · ESLint · `next build` 통과

다만 로컬은 프로덕션보다 빨라서 **12초 타임아웃이 실제 회선에서 충분한지는 배포 후 재확인이 필요**하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)